### PR TITLE
build: add entt, vulkan_sdk and glm to project dependencies

### DIFF
--- a/src/hw.cpp
+++ b/src/hw.cpp
@@ -1,6 +1,20 @@
 #include <iostream>
+#include <entt/entt.hpp>
+#define GLM_ENABLE_EXPERIMENTAL
+#include <glm/glm.hpp>
+#include "glm/gtx/string_cast.hpp"
+#define GLFW_INCLUDE_VULKAN
+#include <GLFW/glfw3.h>
+#include <string>
 
 void hw(void)
 {
 	std::cout << "Hello World!" << std::endl;
+	entt::registry e;
+	std::cout << (int)e.create() << std::endl;
+	glm::vec3 a(1, 2, 3);
+	std::cout << glm::to_string(a) << std::endl;
+	VkVertexInputBindingDescription bindingDescription = {};
+	bindingDescription.binding = 42;
+	std::cout << bindingDescription.binding << std::endl;
 }

--- a/xmake.lua
+++ b/xmake.lua
@@ -1,10 +1,18 @@
 add_rules("mode.debug", "mode.release")
-add_requires("entt")
+add_requires("entt", "vulkan-headers", "vulkansdk", "vulkan-hpp", "glfw", "glm")
 
+add_rules("plugin.vsxmake.autoupdate")
 target("EngineSquared")
     set_kind("static")
+    set_default(true)
+    set_languages("cxx20")
     add_files("src/*.cpp")
     add_files("src/**/*.cpp")
+    add_includedirs("src")
     set_policy("build.warning", true)
-    add_packages("entt")
+    add_packages("entt", "vulkansdk", "glfw", "glm")
     set_languages("cxx20")
+
+    if is_mode("debug") then
+        add_defines("DEBUG")
+    end


### PR DESCRIPTION
Linked to:
- #4 

I've added required dependencies of the issue and some other rules for compilation like define `DEBUG` when compiling in debug mode or set `EngineSquared` as the default target.