### PR TITLE
ci: remove execution of mirroring job on pull request event

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches-ignore:
      - 'ga-ignore-**'
-  pull_request:
-    branches-ignore:
-     - 'ga-ignore-**'
 
 env:
   MIRROR_URL: "git@github.com:EpitechPromo2026/G-EIP-700-NAN-7-1-eip-lucas.hauszler.git"


### PR DESCRIPTION
Related to:
- #17

This line caused double execution of mirroring job on a PR.