### PR TITLE
refactor(Log): remove xmake add_files of cpp where cpp doesn't exist

### DIFF
--- a/src/utils/log/xmake.lua
+++ b/src/utils/log/xmake.lua
@@ -5,6 +5,5 @@ set_languages("cxx20")
 target("UtilsLog")
     set_kind("static")
     add_packages("spdlog")
-    
-    add_files("src/**.cpp")
+
     add_includedirs("src/", {public = true})


### PR DESCRIPTION
I leaved an `add_files` that include cpp files that doesn't exist.
It blocked me while I tried to use Engine² for another plugin