### PR TITLE
fix: soft body physics breaking at low framerates

### DIFF
--- a/src/plugin/physics/src/system/SoftBodyCollision.cpp
+++ b/src/plugin/physics/src/system/SoftBodyCollision.cpp
@@ -77,7 +77,7 @@ void ES::Plugin::Physics::System::DetectSoftBodyCollisions(ES::Engine::Registry 
 
 void ES::Plugin::Physics::System::ApplySoftBodyCollisions(ES::Engine::Registry &registry)
 {
-    auto dt = registry.GetResource<ES::Plugin::Time::Resource::RealTimeProvider>().GetElapsedTime();
+    auto dt = registry.GetFixedDeltaTime();
     auto nodeView = registry.GetRegistry().view<ES::Plugin::Physics::Component::ParticleBoxCollision>();
 
     for (auto entity : nodeView)

--- a/src/plugin/physics/src/system/VelocityIntegration.cpp
+++ b/src/plugin/physics/src/system/VelocityIntegration.cpp
@@ -36,11 +36,10 @@ static void ApplySpringForces(ES::Engine::Registry &registry)
 
 static void IntegrateVelocities(ES::Engine::Registry &registry)
 {
-    auto realTimeProvider = registry.GetResource<ES::Plugin::Time::Resource::RealTimeProvider>();
     auto nodeView = registry.GetRegistry()
                         .view<ES::Plugin::Physics::Component::SoftBodyNode, ES::Plugin::Object::Component::Transform>();
 
-    float dt = realTimeProvider.GetElapsedTime();
+    float dt = registry.GetFixedDeltaTime();
 
     for (auto entity : nodeView)
     {


### PR DESCRIPTION
Related to:
- #45 

Following #61 we are now able to fix this bug easily.
Although this works perfectly fine, the precision of the simulation could be improved even more by using substeping, but this is for another issue.