### PR TITLE
ci: xmake display test output

### DIFF
--- a/src/plugin/object/tests/AssetsManagerTest.cpp
+++ b/src/plugin/object/tests/AssetsManagerTest.cpp
@@ -16,7 +16,7 @@ TEST(Registry, CreateEntity)
     ES::Plugin::Object::Utils::AssetID assetID = assets_manager.Add(std::move(asset));
 
     EXPECT_EQ(assets_manager.Get(assetID).value, 42);
-    EXPECT_EQ(assets_manager.Contains(assetID), false);
+    EXPECT_EQ(assets_manager.Contains(assetID), true);
 
     assets_manager.Remove(assetID);
 


### PR DESCRIPTION
Related to:
- #70 

To summarise, I set the diagnostic flag for the test, and it will generate the *.stdout.log files containing the FAILED test information.