### PR TITLE
ci: use xmake install github action

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -55,18 +55,15 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libvulkan-dev
 
-      - uses: actions/cache@v3
-        name: Store XMake repositories in cache
-        with:
-          path: ~/.xmake
-          key: ${{ runner.os }}-xmake-entt-vulkan-glm
-          restore-keys: |
-            ${{ runner.os }}-xmake-entt-vulkan-glm
-
       - name: Install xmake
         uses: xmake-io/github-action-setup-xmake@v1
         with:
           xmake-version: latest
+          actions-cache-folder: '.xmake-cache'
+          actions-cache-key: '${{ runner.os }}-xmake-install'
+          package-cache: true
+          package-cache-key: '${{ runner.os }}-xmake-entt-vulkan-glm'
+          project-path: '.'
 
       - name: (Try to) build the project
         run: xmake build -y
@@ -112,18 +109,15 @@ jobs:
         run: |
           pip3 install gcovr
 
-      - uses: actions/cache@v3
-        name: Store XMake repositories in cache
-        with:
-          path: ~/.xmake
-          key: ${{ runner.os }}-xmake-entt-vulkan-glm
-          restore-keys: |
-            ${{ runner.os }}-xmake-entt-vulkan-glm
-
       - name: Install xmake
         uses: xmake-io/github-action-setup-xmake@v1
         with:
           xmake-version: latest
+          actions-cache-folder: '.xmake-cache'
+          actions-cache-key: '${{ runner.os }}-xmake-install'
+          package-cache: true
+          package-cache-key: '${{ runner.os }}-xmake-entt-vulkan-glm'
+          project-path: '.'
 
       - name: Starts tests
         run: |

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: (Try to) build the project
         run: xmake build -y
-        timeout-minutes: 20
+        timeout-minutes: 5
 
       - name: Verifies that files are present and executable
         run: |
@@ -130,7 +130,7 @@ jobs:
             done
             exit 1
           }
-        timeout-minutes: 20
+        timeout-minutes: 5
 
       - name: Check tests coverage
         uses: threeal/gcovr-action@v1.1.0

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: (Try to) build the project
         run: xmake build -y
-        timeout-minutes: 2
+        timeout-minutes: 20
 
       - name: Verifies that files are present and executable
         run: |
@@ -130,7 +130,7 @@ jobs:
             done
             exit 1
           }
-        timeout-minutes: 2
+        timeout-minutes: 20
 
       - name: Check tests coverage
         uses: threeal/gcovr-action@v1.1.0

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -64,8 +64,9 @@ jobs:
             ${{ runner.os }}-xmake-entt-vulkan-glm
 
       - name: Install xmake
-        run: |
-          curl -fsSL https://xmake.io/shget.text | bash
+        uses: xmake-io/github-action-setup-xmake@v1
+        with:
+          xmake-version: latest
 
       - name: (Try to) build the project
         run: xmake build -y
@@ -120,8 +121,9 @@ jobs:
             ${{ runner.os }}-xmake-entt-vulkan-glm
 
       - name: Install xmake
-        run: |
-          curl -fsSL https://xmake.io/shget.text | bash
+        uses: xmake-io/github-action-setup-xmake@v1
+        with:
+          xmake-version: latest
 
       - name: Starts tests
         run: |

--- a/src/plugin/utils/src/HasChanged.hpp
+++ b/src/plugin/utils/src/HasChanged.hpp
@@ -6,6 +6,5 @@ namespace ES::Plugin::Tools {
  *
  * @tparam  T   The type of the object
  */
-template <typename T> struct HasChanged {
-};
+template <typename T> struct HasChanged {};
 } // namespace ES::Plugin::Tools


### PR DESCRIPTION
Related to:
- #58 

Use of xmake's official [GitHub Action](https://github.com/xmake-io/github-action-setup-xmake/) for xmake initial setup.

(This PR is not critical)