### PR TITLE
feat(AssetsManager): add id key param when adding an asset

### DIFF
--- a/src/plugin/object/src/resource/AssetsManager.hpp
+++ b/src/plugin/object/src/resource/AssetsManager.hpp
@@ -27,7 +27,7 @@ template <typename TAssetType> class AssetsManager {
     {
         if (_assets.contains(id))
         {
-            ES::Utils::Log::Warn("Asset with id " + std::to_string(id) + " already exists. Overwriting.");
+            ES::Utils::Log::Warn(std::format("Asset with id {} already exists. Overwriting.", id));
         }
         _assets[id] = std::make_shared<TAssetType>(std::move(asset));
         return *_assets[id];

--- a/src/plugin/object/src/resource/AssetsManager.hpp
+++ b/src/plugin/object/src/resource/AssetsManager.hpp
@@ -2,6 +2,8 @@
 
 #include <unordered_map>
 
+#include "Logger.hpp"
+
 #include "AssetID.hpp"
 
 namespace ES::Plugin::Object::Resource {
@@ -21,12 +23,13 @@ template <typename TAssetType> class AssetsManager {
      * \param   asset   asset to be added
      * \return  id of the added asset
      */
-    ES::Plugin::Object::Utils::AssetID Add(TAssetType &&asset)
+    TAssetType &Add(const ES::Plugin::Object::Utils::AssetID &id, TAssetType &&asset)
     {
-        static ES::Plugin::Object::Utils::AssetID id = 1;
-        id++;
-        _assets[id] = std::make_shared<TAssetType>(std::move(asset));
-        return id;
+      if (_assets.contains(id)) {
+        ES::Utils::Log::Warn("Asset with id " + std::to_string(id) + " already exists. Overwriting.");
+      }
+      _assets[id] = std::make_shared<TAssetType>(std::move(asset));
+      return *_assets[id];
     }
 
     /**

--- a/src/plugin/object/tests/AssetsManagerTest.cpp
+++ b/src/plugin/object/tests/AssetsManagerTest.cpp
@@ -13,12 +13,12 @@ TEST(Core, CreateEntity)
     AssetsManager<TestAssets> assets_manager;
     TestAssets asset{42};
 
-    ES::Plugin::Object::Utils::AssetID assetID = assets_manager.Add(std::move(asset));
+    assets_manager.Add(1, std::move(asset));
 
-    EXPECT_EQ(assets_manager.Get(assetID).value, 42);
-    EXPECT_EQ(assets_manager.Contains(assetID), true);
+    EXPECT_EQ(assets_manager.Get(1).value, 42);
+    EXPECT_EQ(assets_manager.Contains(1), true);
 
-    assets_manager.Remove(assetID);
+    assets_manager.Remove(1);
 
-    EXPECT_EQ(assets_manager.Contains(assetID), false);
+    EXPECT_EQ(assets_manager.Contains(1), false);
 }

--- a/src/plugin/ui/xmake.lua
+++ b/src/plugin/ui/xmake.lua
@@ -43,7 +43,7 @@ for _, file in ipairs(os.files("tests/**.cpp")) do
         set_languages("cxx20")
         add_links("gtest")
         add_tests("default")
-        add_packages("glm", "entt", "gtest")
+        add_packages("glm", "entt", "gtest", "spdlog")
         
         add_deps("PluginUI")
         add_deps("EngineSquaredCore")


### PR DESCRIPTION
Not linked to any issues.

This modify API of AssetsManager to be more convenient to use with string. It can allow to use hashed string as key and then, know key in all the program even if we don't get it through creation of asset