### PR TITLE
refactor: creating ESQ Entity instead of ENTT

### DIFF
--- a/src/engine/src/core/Core.cpp
+++ b/src/engine/src/core/Core.cpp
@@ -1,4 +1,5 @@
 #include "Core.hpp"
+#include "Entity.hpp"
 
 ES::Engine::Core::Core() : _registry(nullptr)
 {
@@ -11,7 +12,7 @@ ES::Engine::Core::Core() : _registry(nullptr)
     this->RegisterScheduler<ES::Engine::Scheduler::RelativeTimeUpdate>();
 }
 
-entt::entity ES::Engine::Core::CreateEntity() { return this->_registry->create(); }
+ES::Engine::Entity ES::Engine::Core::CreateEntity() { return ES::Engine::Entity(this->_registry->create()); }
 
 void ES::Engine::Core::RunSystems()
 {

--- a/src/engine/src/core/Core.cpp
+++ b/src/engine/src/core/Core.cpp
@@ -12,7 +12,10 @@ ES::Engine::Core::Core() : _registry(nullptr)
     this->RegisterScheduler<ES::Engine::Scheduler::RelativeTimeUpdate>();
 }
 
-ES::Engine::Entity ES::Engine::Core::CreateEntity() { return static_cast<ES::Engine::Entity>(this->_registry->create()); }
+ES::Engine::Entity ES::Engine::Core::CreateEntity()
+{
+    return static_cast<ES::Engine::Entity>(this->_registry->create());
+}
 
 void ES::Engine::Core::RunSystems()
 {

--- a/src/engine/src/core/Core.cpp
+++ b/src/engine/src/core/Core.cpp
@@ -12,7 +12,7 @@ ES::Engine::Core::Core() : _registry(nullptr)
     this->RegisterScheduler<ES::Engine::Scheduler::RelativeTimeUpdate>();
 }
 
-ES::Engine::Entity ES::Engine::Core::CreateEntity() { return ES::Engine::Entity(this->_registry->create()); }
+ES::Engine::Entity ES::Engine::Core::CreateEntity() { return static_cast<ES::Engine::Entity>(this->_registry->create()); }
 
 void ES::Engine::Core::RunSystems()
 {

--- a/src/engine/src/core/Core.hpp
+++ b/src/engine/src/core/Core.hpp
@@ -21,6 +21,12 @@ namespace ES::Engine {
  * To use ECS, you need to create a registry and register all the components and systems you need and after that
  * you can create entities and add components to them.
  */
+
+ /* Forward declaration to the ES::Engine::Entity class
+  * Required to avoid include loop between Entity and Core headers
+  */
+class Entity;
+
 class Core {
   private:
     using USystem = std::function<void(Core &)>;
@@ -41,7 +47,7 @@ class Core {
      *
      * @return  The entity created.
      */
-    entt::entity CreateEntity();
+    ES::Engine::Entity CreateEntity();
 
     /**
      * Store a resource instance.

--- a/src/engine/src/entity/Entity.hpp
+++ b/src/engine/src/entity/Entity.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "Core.hpp"
 #include <entt/entt.hpp>
 #include <typeindex>
+#include "Core.hpp"
 
 namespace ES::Engine {
 /**

--- a/src/engine/tests/engine/EntityTest.cpp
+++ b/src/engine/tests/engine/EntityTest.cpp
@@ -12,7 +12,7 @@ TEST(Core, TemporaryComponent)
 {
     Core reg;
 
-    auto entity = Entity(reg.CreateEntity());
+    auto entity = reg.CreateEntity();
 
     entity.AddTemporaryComponent<TempComponent>(reg);
 

--- a/src/plugin/native-scripting/tests/ScriptTest.cpp
+++ b/src/plugin/native-scripting/tests/ScriptTest.cpp
@@ -30,7 +30,7 @@ static void InitPlayer(ES::Engine::Core &core)
 {
     float speed = 1.0f;
 
-    ES::Engine::Entity playerEntity(core.CreateEntity());
+    ES::Engine::Entity playerEntity = core.CreateEntity();
     auto &scriptComponent = playerEntity.AddComponent<ES::Plugin::NativeScripting::Component::NativeScripting>(core);
 
     scriptComponent.Bind<speedManager>(core);

--- a/src/plugin/physics/tests/CollisionsTest3D.cpp
+++ b/src/plugin/physics/tests/CollisionsTest3D.cpp
@@ -11,30 +11,30 @@ using namespace ES::Plugin::Physics;
 
 TEST(Collision, CollisionSystemWithBoxCollider3D)
 {
-    ES::Engine::Core registry;
+    ES::Engine::Core core;
 
-    ES::Engine::Entity eA(registry.CreateEntity());
-    ES::Engine::Entity eB(registry.CreateEntity());
+    ES::Engine::Entity eA = core.CreateEntity();
+    ES::Engine::Entity eB = core.CreateEntity();
 
-    eA.AddComponent<ES::Plugin::Physics::Component::BoxCollider3D>(registry, glm::vec3(1, 1, 1));
-    eB.AddComponent<ES::Plugin::Physics::Component::BoxCollider3D>(registry, glm::vec3(1, 1, 1));
-    eA.AddComponent<ES::Plugin::Object::Component::Transform>(registry, glm::vec3(1, 1, 1));
-    eB.AddComponent<ES::Plugin::Object::Component::Transform>(registry, glm::vec3(1, 1, 1));
+    eA.AddComponent<ES::Plugin::Physics::Component::BoxCollider3D>(core, glm::vec3(1, 1, 1));
+    eB.AddComponent<ES::Plugin::Physics::Component::BoxCollider3D>(core, glm::vec3(1, 1, 1));
+    eA.AddComponent<ES::Plugin::Object::Component::Transform>(core, glm::vec3(1, 1, 1));
+    eB.AddComponent<ES::Plugin::Object::Component::Transform>(core, glm::vec3(1, 1, 1));
 
-    registry.RegisterSystem(ES::Plugin::Physics::System::RemoveABABCollisions);
-    registry.RegisterSystem(ES::Plugin::Physics::System::DetectABABCollisions);
+    core.RegisterSystem(ES::Plugin::Physics::System::RemoveABABCollisions);
+    core.RegisterSystem(ES::Plugin::Physics::System::DetectABABCollisions);
 
-    registry.RunSystems();
+    core.RunSystems();
 
-    auto view = registry.GetRegistry().view<ES::Plugin::Physics::Component::ABABCollision3D>();
+    auto view = core.GetRegistry().view<ES::Plugin::Physics::Component::ABABCollision3D>();
 
     EXPECT_EQ(view.size(), 1);
 
-    eA.GetComponents<ES::Plugin::Object::Component::Transform>(registry).setPosition(9, 9, 9);
+    eA.GetComponents<ES::Plugin::Object::Component::Transform>(core).setPosition(9, 9, 9);
 
-    registry.RunSystems();
+    core.RunSystems();
 
-    view = registry.GetRegistry().view<ES::Plugin::Physics::Component::ABABCollision3D>();
+    view = core.GetRegistry().view<ES::Plugin::Physics::Component::ABABCollision3D>();
 
     EXPECT_EQ(view.size(), 0);
 }

--- a/src/plugin/physics/tests/SoftBodyCollisionsTest.cpp
+++ b/src/plugin/physics/tests/SoftBodyCollisionsTest.cpp
@@ -12,63 +12,63 @@
 
 TEST(SoftBodyCollisions, BasicParticleCollision)
 {
-    ES::Engine::Core registry;
+    ES::Engine::Core core;
 
-    registry.RegisterSystem(ES::Plugin::Physics::System::DetectSoftBodyCollisions);
+    core.RegisterSystem(ES::Plugin::Physics::System::DetectSoftBodyCollisions);
 
-    ES::Engine::Entity particle = registry.CreateEntity();
-    registry.GetRegistry().emplace<ES::Plugin::Object::Component::Transform>(particle, glm::vec3(0, 1, 0));
-    registry.GetRegistry().emplace<ES::Plugin::Physics::Component::SoftBodyNode>(particle);
+    ES::Engine::Entity particle = core.CreateEntity();
+    core.GetRegistry().emplace<ES::Plugin::Object::Component::Transform>(particle, glm::vec3(0, 1, 0));
+    core.GetRegistry().emplace<ES::Plugin::Physics::Component::SoftBodyNode>(particle);
 
-    ES::Engine::Entity ground = registry.CreateEntity();
-    registry.GetRegistry().emplace<ES::Plugin::Object::Component::Transform>(ground, glm::vec3(0, 0, 0));
-    registry.GetRegistry().emplace<ES::Plugin::Physics::Component::BoxCollider3D>(ground, glm::vec3(2, 2, 2));
+    ES::Engine::Entity ground = core.CreateEntity();
+    core.GetRegistry().emplace<ES::Plugin::Object::Component::Transform>(ground, glm::vec3(0, 0, 0));
+    core.GetRegistry().emplace<ES::Plugin::Physics::Component::BoxCollider3D>(ground, glm::vec3(2, 2, 2));
 
-    registry.RunSystems();
+    core.RunSystems();
 
-    auto view = registry.GetRegistry().view<ES::Plugin::Physics::Component::ParticleBoxCollision>();
+    auto view = core.GetRegistry().view<ES::Plugin::Physics::Component::ParticleBoxCollision>();
 
     ASSERT_GT(view.size(), 0);
 
     for (auto &entity : view)
     {
-        registry.GetRegistry().destroy(entity);
+        core.GetRegistry().destroy(entity);
     }
 
-    registry.GetRegistry().emplace<ES::Plugin::Object::Component::Transform>(particle, glm::vec3(0, 100, 0));
+    core.GetRegistry().emplace<ES::Plugin::Object::Component::Transform>(particle, glm::vec3(0, 100, 0));
 
-    registry.RunSystems();
+    core.RunSystems();
 
-    view = registry.GetRegistry().view<ES::Plugin::Physics::Component::ParticleBoxCollision>();
+    view = core.GetRegistry().view<ES::Plugin::Physics::Component::ParticleBoxCollision>();
 
     ASSERT_EQ(view.size(), 0);
 }
 
 TEST(SoftBodyCollisions, VelocityIntegrationWithBasicCollision)
 {
-    ES::Engine::Core registry;
+    ES::Engine::Core core;
 
-    registry.RegisterSystem(ES::Plugin::Physics::System::DetectSoftBodyCollisions);
-    registry.RegisterSystem(ES::Plugin::Physics::System::VelocityIntegration);
-    registry.RegisterSystem(ES::Plugin::Physics::System::ApplySoftBodyCollisions);
+    core.RegisterSystem(ES::Plugin::Physics::System::DetectSoftBodyCollisions);
+    core.RegisterSystem(ES::Plugin::Physics::System::VelocityIntegration);
+    core.RegisterSystem(ES::Plugin::Physics::System::ApplySoftBodyCollisions);
 
-    ES::Engine::Entity particle = registry.CreateEntity();
-    registry.GetRegistry().emplace<ES::Plugin::Object::Component::Transform>(particle, glm::vec3(0, 2.1, 0));
-    registry.GetRegistry().emplace<ES::Plugin::Physics::Component::SoftBodyNode>(particle);
+    ES::Engine::Entity particle = core.CreateEntity();
+    core.GetRegistry().emplace<ES::Plugin::Object::Component::Transform>(particle, glm::vec3(0, 2.1, 0));
+    core.GetRegistry().emplace<ES::Plugin::Physics::Component::SoftBodyNode>(particle);
 
-    ES::Engine::Entity ground = registry.CreateEntity();
-    registry.GetRegistry().emplace<ES::Plugin::Object::Component::Transform>(ground, glm::vec3(0, 0, 0));
-    registry.GetRegistry().emplace<ES::Plugin::Physics::Component::BoxCollider3D>(ground, glm::vec3(2, 2, 2));
+    ES::Engine::Entity ground = core.CreateEntity();
+    core.GetRegistry().emplace<ES::Plugin::Object::Component::Transform>(ground, glm::vec3(0, 0, 0));
+    core.GetRegistry().emplace<ES::Plugin::Physics::Component::BoxCollider3D>(ground, glm::vec3(2, 2, 2));
 
-    auto const &node = registry.GetRegistry().get<ES::Plugin::Physics::Component::SoftBodyNode>(particle);
-    auto const &transform = registry.GetRegistry().get<ES::Plugin::Object::Component::Transform>(particle);
+    auto const &node = core.GetRegistry().get<ES::Plugin::Physics::Component::SoftBodyNode>(particle);
+    auto const &transform = core.GetRegistry().get<ES::Plugin::Object::Component::Transform>(particle);
 
     bool bounced = false;
 
     for (int i = 0; i < 100; i++)
     {
         SleepFor(10);
-        registry.RunSystems();
+        core.RunSystems();
 
         if (node.velocity.y > 0)
         {

--- a/src/plugin/physics/tests/VelocityIntegrationTest.cpp
+++ b/src/plugin/physics/tests/VelocityIntegrationTest.cpp
@@ -13,19 +13,19 @@
 
 TEST(VelocityIntegration, BasicGravityIntegration)
 {
-    ES::Engine::Core registry;
-    registry.RegisterSystem(ES::Plugin::Physics::System::VelocityIntegration);
+    ES::Engine::Core core;
+    core.RegisterSystem(ES::Plugin::Physics::System::VelocityIntegration);
 
-    ES::Engine::Entity entity = registry.CreateEntity();
-    registry.GetRegistry().emplace<ES::Plugin::Object::Component::Transform>(entity, glm::vec3(0));
-    registry.GetRegistry().emplace<ES::Plugin::Physics::Component::SoftBodyNode>(entity);
+    ES::Engine::Entity entity = core.CreateEntity();
+    core.GetRegistry().emplace<ES::Plugin::Object::Component::Transform>(entity, glm::vec3(0));
+    core.GetRegistry().emplace<ES::Plugin::Physics::Component::SoftBodyNode>(entity);
 
-    auto const &node = registry.GetRegistry().get<ES::Plugin::Physics::Component::SoftBodyNode>(entity);
-    auto const &transform = registry.GetRegistry().get<ES::Plugin::Object::Component::Transform>(entity);
+    auto const &node = core.GetRegistry().get<ES::Plugin::Physics::Component::SoftBodyNode>(entity);
+    auto const &transform = core.GetRegistry().get<ES::Plugin::Object::Component::Transform>(entity);
 
     // registry uses a real time provider to get the elapsed time, so we should sleep a bit
     SleepFor(10);
-    registry.RunSystems();
+    core.RunSystems();
     // gravity is applied to the node, so the position should be negative
     EXPECT_LT(transform.position.y, 0);
     // velocity should be as well
@@ -36,20 +36,20 @@ TEST(VelocityIntegration, BasicGravityIntegration)
 
 TEST(VelocityIntegration, ForceHigherThanGravity)
 {
-    ES::Engine::Core registry;
-    registry.RegisterSystem(ES::Plugin::Physics::System::VelocityIntegration);
+    ES::Engine::Core core;
+    core.RegisterSystem(ES::Plugin::Physics::System::VelocityIntegration);
 
-    ES::Engine::Entity entity = registry.CreateEntity();
-    registry.GetRegistry().emplace<ES::Plugin::Object::Component::Transform>(entity, glm::vec3(0));
-    registry.GetRegistry().emplace<ES::Plugin::Physics::Component::SoftBodyNode>(entity);
+    ES::Engine::Entity entity = core.CreateEntity();
+    core.GetRegistry().emplace<ES::Plugin::Object::Component::Transform>(entity, glm::vec3(0));
+    core.GetRegistry().emplace<ES::Plugin::Physics::Component::SoftBodyNode>(entity);
 
-    auto &node = registry.GetRegistry().get<ES::Plugin::Physics::Component::SoftBodyNode>(entity);
-    auto const &transform = registry.GetRegistry().get<ES::Plugin::Object::Component::Transform>(entity);
+    auto &node = core.GetRegistry().get<ES::Plugin::Physics::Component::SoftBodyNode>(entity);
+    auto const &transform = core.GetRegistry().get<ES::Plugin::Object::Component::Transform>(entity);
 
     node.ApplyForce(glm::vec3(0, 100, 0));
 
     SleepFor(10);
-    registry.RunSystems();
+    core.RunSystems();
     // here position should be positive
     EXPECT_GT(transform.position.y, 0);
     // velocity should be as well

--- a/src/plugin/scene/tests/SceneTest.cpp
+++ b/src/plugin/scene/tests/SceneTest.cpp
@@ -26,19 +26,19 @@ class SceneTest : public Utils::AScene {
 
 TEST(Scene, SceneManager)
 {
-    ES::Engine::Core registry;
-    registry.RegisterResource<Resource::SceneManager>(Resource::SceneManager());
-    registry.GetResource<Resource::SceneManager>().RegisterScene<SceneTest>("scene1");
-    registry.GetResource<Resource::SceneManager>().RegisterScene<SceneTest>("scene2");
+    ES::Engine::Core core;
+    core.RegisterResource<Resource::SceneManager>(Resource::SceneManager());
+    core.GetResource<Resource::SceneManager>().RegisterScene<SceneTest>("scene1");
+    core.GetResource<Resource::SceneManager>().RegisterScene<SceneTest>("scene2");
 
-    registry.GetResource<Resource::SceneManager>().SetNextScene("scene1");
+    core.GetResource<Resource::SceneManager>().SetNextScene("scene1");
 
     testing::internal::CaptureStdout();
-    registry.RegisterSystem(System::UpdateScene);
-    registry.RunSystems();
+    core.RegisterSystem(System::UpdateScene);
+    core.RunSystems();
 
-    registry.GetResource<Resource::SceneManager>().SetNextScene("scene2");
-    registry.RunSystems();
+    core.GetResource<Resource::SceneManager>().SetNextScene("scene2");
+    core.RunSystems();
     std::vector<std::string> output = ES::Plugin::Utils::String::Split(testing::internal::GetCapturedStdout(), '\n');
     EXPECT_TRUE(ES::Plugin::Utils::String::EndsWith(output[0], "Loading scene: scene1"));
     EXPECT_TRUE(ES::Plugin::Utils::String::EndsWith(output[1], "Unloading scene: scene1"));

--- a/src/plugin/ui/tests/Button.cpp
+++ b/src/plugin/ui/tests/Button.cpp
@@ -11,41 +11,41 @@ TEST(Button, ButtonClick)
     struct onClickCalled {
         bool clicked = false;
     };
-    ES::Engine::Core r;
-    r.RegisterSystem(System::ButtonClick);
-    r.RegisterSystem(ES::Engine::Entity::RemoveTemporaryComponents);
+    ES::Engine::Core core;
+    core.RegisterSystem(System::ButtonClick);
+    core.RegisterSystem(ES::Engine::Entity::RemoveTemporaryComponents);
 
-    r.RegisterResource<onClickCalled>(onClickCalled());
+    core.RegisterResource<onClickCalled>(onClickCalled());
 
-    auto button = ES::Engine::Entity(r.CreateEntity());
-    button.AddComponent<Component::Button>(r);
+    auto button = core.CreateEntity();
+    button.AddComponent<Component::Button>(core);
 
-    auto &buttonComponent = button.GetComponents<Component::Button>(r);
+    auto &buttonComponent = button.GetComponents<Component::Button>(core);
     buttonComponent.lastState = Component::Button::State::Pressed;
     buttonComponent.state = Component::Button::State::Hover;
 
     buttonComponent.onClick = [](ES::Engine::Core &reg) { reg.GetResource<onClickCalled>().clicked = true; };
 
-    EXPECT_FALSE(r.GetResource<onClickCalled>().clicked);
+    EXPECT_FALSE(core.GetResource<onClickCalled>().clicked);
 
-    button.AddTemporaryComponent<ES::Plugin::Tools::HasChanged<Component::Button>>(r);
-    r.RunSystems();
+    button.AddTemporaryComponent<ES::Plugin::Tools::HasChanged<Component::Button>>(core);
+    core.RunSystems();
 
-    EXPECT_TRUE(r.GetResource<onClickCalled>().clicked);
+    EXPECT_TRUE(core.GetResource<onClickCalled>().clicked);
 }
 
 TEST(Button, UpdateButtonTexture)
 {
-    ES::Engine::Core r;
+    ES::Engine::Core core;
 
-    r.RegisterSystem(System::UpdateButtonTexture);
-    r.RegisterSystem(ES::Engine::Entity::RemoveTemporaryComponents);
+    core.RegisterSystem(System::UpdateButtonTexture);
+    core.RegisterSystem(ES::Engine::Entity::RemoveTemporaryComponents);
 
-    auto button = ES::Engine::Entity(r.CreateEntity());
-    button.AddComponent<Component::Button>(r);
-    button.AddComponent<Component::Sprite2D>(r);
+    auto button = core.CreateEntity();
+    button.AddComponent<Component::Button>(core);
+    button.AddComponent<Component::Sprite2D>(core);
 
-    auto &buttonComponent = button.GetComponents<Component::Button>(r);
+    auto &buttonComponent = button.GetComponents<Component::Button>(core);
     buttonComponent.displayType =
         Component::DisplayType::TintColor{.imageID = ES::Plugin::Object::Utils::NULL_ASSET_ID,
                                           .normalColor = ES::Plugin::Colors::Utils::WHITE_COLOR,
@@ -53,17 +53,17 @@ TEST(Button, UpdateButtonTexture)
                                           .pressedColor = ES::Plugin::Colors::Utils::DARKGRAY_COLOR};
 
     buttonComponent.state = Component::Button::State::Hover;
-    button.AddTemporaryComponent<ES::Plugin::Tools::HasChanged<Component::Button>>(r);
-    r.RunSystems();
-    EXPECT_EQ(button.GetComponents<Component::Sprite2D>(r).color, ES::Plugin::Colors::Utils::GRAY_COLOR);
+    button.AddTemporaryComponent<ES::Plugin::Tools::HasChanged<Component::Button>>(core);
+    core.RunSystems();
+    EXPECT_EQ(button.GetComponents<Component::Sprite2D>(core).color, ES::Plugin::Colors::Utils::GRAY_COLOR);
 
     buttonComponent.state = Component::Button::State::Pressed;
-    button.AddTemporaryComponent<ES::Plugin::Tools::HasChanged<Component::Button>>(r);
-    r.RunSystems();
-    EXPECT_EQ(button.GetComponents<Component::Sprite2D>(r).color, ES::Plugin::Colors::Utils::DARKGRAY_COLOR);
+    button.AddTemporaryComponent<ES::Plugin::Tools::HasChanged<Component::Button>>(core);
+    core.RunSystems();
+    EXPECT_EQ(button.GetComponents<Component::Sprite2D>(core).color, ES::Plugin::Colors::Utils::DARKGRAY_COLOR);
 
     buttonComponent.state = Component::Button::State::Normal;
-    button.AddTemporaryComponent<ES::Plugin::Tools::HasChanged<Component::Button>>(r);
-    r.RunSystems();
-    EXPECT_EQ(button.GetComponents<Component::Sprite2D>(r).color, ES::Plugin::Colors::Utils::WHITE_COLOR);
+    button.AddTemporaryComponent<ES::Plugin::Tools::HasChanged<Component::Button>>(core);
+    core.RunSystems();
+    EXPECT_EQ(button.GetComponents<Component::Sprite2D>(core).color, ES::Plugin::Colors::Utils::WHITE_COLOR);
 }


### PR DESCRIPTION
Related to:
- #100

I also renamed missing `registry` variables into `core` in various files to follow the naming convention. 