### PR TITLE
fix(Window): rename CreateWindow system to CreateWindowSystem

### DIFF
--- a/src/plugin/window/src/system/WindowSystem.cpp
+++ b/src/plugin/window/src/system/WindowSystem.cpp
@@ -2,7 +2,7 @@
 
 namespace ES::Plugin::Window::System {
 
-void CreateWindow(ES::Engine::Core &core)
+void CreateWindowSystem(ES::Engine::Core &core)
 {
     try
     {

--- a/src/plugin/window/src/system/WindowSystem.hpp
+++ b/src/plugin/window/src/system/WindowSystem.hpp
@@ -43,7 +43,7 @@ const int DEFAULT_HEIGHT = 800;
  *
  * @param core  The Engine² Core.
  */
-void CreateWindow(ES::Engine::Core &core);
+void CreateWindowSystem(ES::Engine::Core &core);
 
 /**
  * @brief Enable VSync.


### PR DESCRIPTION
Not linked to any issue.

This PR will fix compilation on windows because `CreateWindow` already exist on this OS so we have to rename it.

> [!CAUTION]
> You will need to rename this system in existing projects 