### PR TITLE
refactor(OpenGL): move shaders into cpp file

### DIFF
--- a/src/plugin/opengl/src/plugin/PluginOpenGL.cpp
+++ b/src/plugin/opengl/src/plugin/PluginOpenGL.cpp
@@ -11,10 +11,12 @@ void ES::Plugin::OpenGL::Plugin::Bind()
     RegisterSystems<ES::Engine::Scheduler::Startup>(ES::Plugin::OpenGL::System::SetupGLFWHints);
     RegisterSystems<ES::Engine::Scheduler::Startup>(ES::Plugin::OpenGL::System::CreateGLFWWindow);
     RegisterSystems<ES::Engine::Scheduler::Startup>(ES::Plugin::OpenGL::System::LinkGLFWContextToGL);
+    RegisterSystems<ES::Engine::Scheduler::Startup>(ES::Plugin::OpenGL::System::InitGLEW);
     RegisterSystems<ES::Engine::Scheduler::Startup>(ES::Plugin::OpenGL::System::CheckGLEWVersion);
     RegisterSystems<ES::Engine::Scheduler::Startup>(ES::Plugin::OpenGL::System::GLFWEnableVSync);
     RegisterSystems<ES::Engine::Scheduler::Startup>(ES::Plugin::OpenGL::System::LoadMaterialCache);
     RegisterSystems<ES::Engine::Scheduler::Startup>(ES::Plugin::OpenGL::System::LoadShaderManager);
+    RegisterSystems<ES::Engine::Scheduler::Startup>(ES::Plugin::OpenGL::System::LoadDefaultShader);
     RegisterSystems<ES::Engine::Scheduler::Startup>(ES::Plugin::OpenGL::System::CreateCamera);
     RegisterSystems<ES::Engine::Scheduler::Startup>(ES::Plugin::OpenGL::System::SetupShaderUniforms);
 

--- a/src/plugin/opengl/src/system/AllSystems.cpp
+++ b/src/plugin/opengl/src/system/AllSystems.cpp
@@ -134,10 +134,82 @@ void ES::Plugin::OpenGL::System::PollEvents(ES::Engine::Core &core) { glfwPollEv
 
 void ES::Plugin::OpenGL::System::LoadShaderManager(ES::Engine::Core &core)
 {
-    Resource::ShaderManager &shaderManager = core.RegisterResource<Resource::ShaderManager>(Resource::ShaderManager());
+    core.RegisterResource<Resource::ShaderManager>(Resource::ShaderManager());
+}
+
+void ES::Plugin::OpenGL::System::LoadDefaultShader(ES::Engine::Core &core)
+{
+    const char *vertexShader = R"(
+        #version 440
+
+        layout (location = 0) in vec4 VertexPosition;
+        layout (location = 1) in vec3 VertexNormal;
+
+        out vec3 Position;
+        out vec3 Normal;
+
+        uniform mat4 ModelMatrix;
+        uniform mat3 NormalMatrix;
+        uniform mat4 MVP;
+
+        void main()
+        {
+            Normal = normalize(NormalMatrix * VertexNormal);
+            Position = (ModelMatrix * VertexPosition).xyz;
+            gl_Position = MVP * VertexPosition;
+        }
+    )";
+
+    const char *fragmentShader = R"(
+        #version 440
+
+        in vec3 Position;
+        in vec3 Normal;
+
+        uniform vec3 CamPos;
+
+        struct LightInfo {
+            vec4 Position; // Light position in eye coords.
+            vec3 Intensity; // Light intensity
+        };
+        uniform LightInfo Light[5];
+
+        struct MaterialInfo {
+            vec3 Ka; // Ambient reflectivity
+            vec3 Kd; // Diffuse reflectivity
+            vec3 Ks; // Specular reflectivity
+            float Shiness; // Specular shininess factor (phong exponent)
+        };
+        uniform MaterialInfo Material;
+
+        out vec4 FragColor;
+
+        void main() {
+            vec3 finalColor = vec3(0,0,0);
+            vec3 ambient = Material.Ka * Light[0].Intensity;
+            for (int i = 0; i < 4; i++) {
+                vec3 L = normalize(Light[i].Position.xyz - Position);
+                vec3 V = normalize(CamPos - Position);
+                vec3 diffuse = Material.Kd * Light[i].Intensity * max( dot(L, Normal), 0.0);
+                vec3 HalfwayVector = normalize(V + L);
+                vec3 specular = Material.Ks * Light[i].Intensity * pow( max( dot( HalfwayVector, Normal), 0.0), Material.Shiness);
+                finalColor = finalColor + diffuse + specular;
+            }
+            vec3 L = normalize(Light[4].Position.xyz);
+            vec3 V = normalize(CamPos - Position);
+            vec3 diffuse = Material.Kd * Light[4].Intensity * max( dot(L, Normal), 0.0);
+            vec3 HalfwayVector = normalize(V + L);
+            vec3 specular = Material.Ks * Light[4].Intensity * pow( max( dot( HalfwayVector, Normal), 0.0), Material.Shiness);
+            finalColor = finalColor + diffuse + specular;
+            finalColor = ambient + finalColor;
+            FragColor = vec4(finalColor, 1.0);
+        }
+    )";
+
+    auto &shaderManager = core.GetResource<Resource::ShaderManager>();
     Utils::ShaderProgram &sp = shaderManager.Add(entt::hashed_string{"default"}, std::move(Utils::ShaderProgram()));
     sp.Create();
-    sp.initFromFiles("shaders/simple.vert", "shaders/simple.frag");
+    sp.initFromStrings(vertexShader, fragmentShader);
 }
 
 void ES::Plugin::OpenGL::System::SetupShaderUniforms(ES::Engine::Core &core)

--- a/src/plugin/opengl/src/system/AllSystems.hpp
+++ b/src/plugin/opengl/src/system/AllSystems.hpp
@@ -40,6 +40,7 @@ void SwapBuffers(ES::Engine::Core &core);
 void PollEvents(ES::Engine::Core &core);
 
 void LoadShaderManager(ES::Engine::Core &core);
+void LoadDefaultShader(ES::Engine::Core &core);
 
 void SetupShaderUniforms(ES::Engine::Core &core);
 void LoadMaterialCache(ES::Engine::Core &core);


### PR DESCRIPTION
Related to:
- #128

As I said in the issue, there 2 possibility to implement that and I've the quickest and easliset way to add a default shader without having it locally in your projet.

I've also added the "InitGLFW" system because without this, you can't use OpenGL plugin :/