### PR TITLE
feat(Scheduler): add deltatime in update

### DIFF
--- a/src/engine/src/scheduler/Update.cpp
+++ b/src/engine/src/scheduler/Update.cpp
@@ -2,6 +2,10 @@
 
 void ES::Engine::Scheduler::Update::RunSystems()
 {
+    auto currentTime = std::chrono::high_resolution_clock::now();
+    _elapsedTime = std::chrono::duration<float>(currentTime - _lastTime).count();
+    _lastTime = currentTime;
+
     for (auto const &system : this->_systemsList.GetSystems())
     {
         (*system)(_registry);

--- a/src/engine/src/scheduler/Update.hpp
+++ b/src/engine/src/scheduler/Update.hpp
@@ -12,7 +12,7 @@ class Update : public AScheduler {
   public:
     using AScheduler::AScheduler;
     void RunSystems() override;
-  
+
     /**
      * @brief Get the current delta time
      * The delta time is the time between the last system run and the current system run.
@@ -24,6 +24,5 @@ class Update : public AScheduler {
   private:
     float _elapsedTime = 0.0f;
     std::chrono::time_point<std::chrono::high_resolution_clock> _lastTime = std::chrono::high_resolution_clock::now();
-
 };
 } // namespace ES::Engine::Scheduler

--- a/src/engine/src/scheduler/Update.hpp
+++ b/src/engine/src/scheduler/Update.hpp
@@ -12,5 +12,18 @@ class Update : public AScheduler {
   public:
     using AScheduler::AScheduler;
     void RunSystems() override;
+  
+    /**
+     * @brief Get the current delta time
+     * The delta time is the time between the last system run and the current system run.
+     *
+     * @return float The current delta time
+     */
+    inline float GetDeltaTime() const { return _elapsedTime; }
+
+  private:
+    float _elapsedTime = 0.0f;
+    std::chrono::time_point<std::chrono::high_resolution_clock> _lastTime = std::chrono::high_resolution_clock::now();
+
 };
 } // namespace ES::Engine::Scheduler


### PR DESCRIPTION
Not related to any issue.

When we want to move a specific object using Update Scheduler, we need (when we want to do it cleanly) to have the delta time since the last update and we currently don't have it so I've added it :)