### PR TITLE
fix: add missing Body header in physics components

### DIFF
--- a/src/plugin/physics/src/component/RigidBody3D.hpp
+++ b/src/plugin/physics/src/component/RigidBody3D.hpp
@@ -4,6 +4,7 @@
 #include <Jolt/Jolt.h>
 // clang-format on
 
+#include <Jolt/Physics/Body/Body.h>
 #include <Jolt/Physics/Body/MotionType.h>
 #include <Jolt/Physics/Collision/ObjectLayer.h>
 #include <Jolt/Physics/Collision/Shape/Shape.h>

--- a/src/plugin/physics/src/component/SoftBody3D.hpp
+++ b/src/plugin/physics/src/component/SoftBody3D.hpp
@@ -4,6 +4,7 @@
 #include <Jolt/Jolt.h>
 // clang-format on
 
+#include <Jolt/Physics/Body/Body.h>
 #include <Jolt/Physics/Body/MotionType.h>
 #include <Jolt/Physics/Collision/ObjectLayer.h>
 #include <Jolt/Physics/Collision/Shape/Shape.h>


### PR DESCRIPTION
When implementing physics in a game, the "JPH::Body" class was a forward declaration which meant that we couldn't use its method externally
This fixes this by including the header in the components that have a JPH::Body