### PR TITLE
feat: add string description when having error while opening a file

### DIFF
--- a/src/plugin/opengl/src/utils/Loader/Loader.hpp
+++ b/src/plugin/opengl/src/utils/Loader/Loader.hpp
@@ -8,6 +8,7 @@
 #include <iostream>
 #include <map>
 #include <sstream>
+#include <string>
 
 #include "Logger.hpp"
 #include "OpenGLError.hpp"
@@ -165,7 +166,7 @@ class ShaderProgram {
         // If we couldn't open the file we'll bail out
         if (!file.good())
         {
-            ES::Utils::Log::Error(fmt::format("Failed to open file: {}", filename));
+            ES::Utils::Log::Error(fmt::format("Failed to open file({}): {}", filename, std::strerror(errno)));
         }
 
         // Otherwise, create a string stream...


### PR DESCRIPTION
I'he added a little more infos when having an error while opening a file.

Why not using / having a library to manage files ? It could also be related to @Divengerss tasks which is saving data.