### PR TITLE
fix(OpenGL): normalize color for hlsl

### DIFF
--- a/src/plugin/opengl/src/system/AllSystems.cpp
+++ b/src/plugin/opengl/src/system/AllSystems.cpp
@@ -217,7 +217,7 @@ void ES::Plugin::OpenGL::System::LoadDefaultSpriteShader(ES::Engine::Core &core)
         uniform vec4 color;
         void main()
         {
-            FragColor = color;
+            FragColor = color / vec4(255.0, 255.0, 255.0, 255.0);
         }
     )";
 


### PR DESCRIPTION
When we send color struct to hlsl, we send char sized color channel but hlsl use 0 to 1 value, so we need to "normalize" it.

We should later see if we need to use float instead of char to avoid normalizing colors. 