### PR TITLE
feat(physics): contact callbacks based on entity components

### DIFF
--- a/src/engine/src/entity/Entity.hpp
+++ b/src/engine/src/entity/Entity.hpp
@@ -198,7 +198,7 @@ class Entity {
      * @tparam  TComponent  components to check
      * @return  true if entity have all requested component
      */
-    template <typename... TComponent> inline bool HasComponents(Core &core)
+    template <typename... TComponent> inline bool HasComponents(Core &core) const
     {
         return core.GetRegistry().all_of<TComponent...>(ToEnttEntity(this->_entity));
     }

--- a/src/plugin/physics/src/resource/PhysicsManager.hpp
+++ b/src/plugin/physics/src/resource/PhysicsManager.hpp
@@ -106,10 +106,12 @@ class PhysicsManager {
      * @brief Add a contact added callback to the contact listener.
      *
      * @param callback The callback to add.
+     * @tparam Components The components to check for in the entities involved in the contact.
      *
      * @return void
      */
-    inline void AddContactAddedCallback(Utils::ContactListenerImpl::OnContactAddedCallback callback)
+    template<typename... Components>
+    inline void AddContactAddedCallback(std::unique_ptr<Utils::ContactCallback<Components...>>&& callback)
     {
         auto contactListener = GetContactListener();
 
@@ -127,13 +129,31 @@ class PhysicsManager {
     }
 
     /**
+     * @brief Add a contact added callback to the contact listener.
+     *
+     * @param fn The callback function to add.
+     * @tparam components The components to check for in the entities involved in the contact.
+     *
+     * @return void
+     * @note This will create a new ContactCallback object and add it to the contact listener.
+     */
+    template<typename... Components>
+    inline void AddContactAddedCallback(Utils::ContactCallback<Components...>::CallbackFunc fn)
+    {
+        auto callback = std::make_unique<Utils::ContactCallback<Components...>>(std::move(fn));
+        AddContactAddedCallback(std::move(callback));
+    }
+
+    /**
      * @brief Add a contact persisted callback to the contact listener.
      *
      * @param callback The callback to add.
+     * @tparam Components The components to check for in the entities involved in the contact.
      *
      * @return void
      */
-    inline void AddContactPersistedCallback(Utils::ContactListenerImpl::OnContactPersistedCallback callback)
+    template<typename... Components>
+    inline void AddContactPersistedCallback(std::unique_ptr<Utils::ContactCallback<Components...>>&& callback)
     {
         auto contactListener = GetContactListener();
 
@@ -151,13 +171,31 @@ class PhysicsManager {
     }
 
     /**
+     * @brief Add a contact persisted callback to the contact listener.
+     *
+     * @param fn The callback function to add.
+     * @tparam components The components to check for in the entities involved in the contact.
+     *
+     * @return void
+     * @note This will create a new ContactCallback object and add it to the contact listener.
+     */
+    template<typename... Components>
+    inline void AddContactPersistedCallback(Utils::ContactCallback<Components...>::CallbackFunc fn)
+    {
+        auto callback = std::make_unique<Utils::ContactCallback<Components...>>(std::move(fn));
+        AddContactPersistedCallback(std::move(callback));
+    }
+
+    /**
      * @brief Add a contact removed callback to the contact listener.
      *
      * @param callback The callback to add.
+     * @tparam Components The components to check for in the entities involved in the contact.
      *
      * @return void
      */
-    inline void AddContactRemovedCallback(Utils::ContactListenerImpl::OnContactRemovedCallback callback)
+    template<typename... Components>
+    inline void AddContactRemovedCallback(std::unique_ptr<Utils::ContactCallback<Components...>>&& callback)
     {
         auto contactListener = GetContactListener();
 
@@ -172,6 +210,22 @@ class PhysicsManager {
                 "PhysicsManager: tried to add contact removed callback, but contact listener is not initialized.");
         }
 #endif
+    }
+
+    /**
+     * @brief Add a contact removed callback to the contact listener.
+     *
+     * @param fn The callback function to add.
+     * @tparam components The components to check for in the entities involved in the contact.
+     *
+     * @return void
+     * @note This will create a new ContactCallback object and add it to the contact listener.
+     */
+    template<typename... Components>
+    inline void AddContactRemovedCallback(Utils::ContactCallback<Components...>::CallbackFunc fn)
+    {
+        auto callback = std::make_unique<Utils::ContactCallback<Components...>>(std::move(fn));
+        AddContactRemovedCallback(std::move(callback));
     }
 
   private:

--- a/src/plugin/physics/src/resource/PhysicsManager.hpp
+++ b/src/plugin/physics/src/resource/PhysicsManager.hpp
@@ -110,8 +110,8 @@ class PhysicsManager {
      *
      * @return void
      */
-    template<typename... Components>
-    inline void AddContactAddedCallback(std::unique_ptr<Utils::ContactCallback<Components...>>&& callback)
+    template <typename... Components>
+    inline void AddContactAddedCallback(std::unique_ptr<Utils::ContactCallback<Components...>> &&callback)
     {
         auto contactListener = GetContactListener();
 
@@ -137,7 +137,7 @@ class PhysicsManager {
      * @return void
      * @note This will create a new ContactCallback object and add it to the contact listener.
      */
-    template<typename... Components>
+    template <typename... Components>
     inline void AddContactAddedCallback(Utils::ContactCallback<Components...>::CallbackFunc fn)
     {
         auto callback = std::make_unique<Utils::ContactCallback<Components...>>(std::move(fn));
@@ -152,8 +152,8 @@ class PhysicsManager {
      *
      * @return void
      */
-    template<typename... Components>
-    inline void AddContactPersistedCallback(std::unique_ptr<Utils::ContactCallback<Components...>>&& callback)
+    template <typename... Components>
+    inline void AddContactPersistedCallback(std::unique_ptr<Utils::ContactCallback<Components...>> &&callback)
     {
         auto contactListener = GetContactListener();
 
@@ -179,7 +179,7 @@ class PhysicsManager {
      * @return void
      * @note This will create a new ContactCallback object and add it to the contact listener.
      */
-    template<typename... Components>
+    template <typename... Components>
     inline void AddContactPersistedCallback(Utils::ContactCallback<Components...>::CallbackFunc fn)
     {
         auto callback = std::make_unique<Utils::ContactCallback<Components...>>(std::move(fn));
@@ -194,8 +194,8 @@ class PhysicsManager {
      *
      * @return void
      */
-    template<typename... Components>
-    inline void AddContactRemovedCallback(std::unique_ptr<Utils::ContactCallback<Components...>>&& callback)
+    template <typename... Components>
+    inline void AddContactRemovedCallback(std::unique_ptr<Utils::ContactCallback<Components...>> &&callback)
     {
         auto contactListener = GetContactListener();
 
@@ -221,7 +221,7 @@ class PhysicsManager {
      * @return void
      * @note This will create a new ContactCallback object and add it to the contact listener.
      */
-    template<typename... Components>
+    template <typename... Components>
     inline void AddContactRemovedCallback(Utils::ContactCallback<Components...>::CallbackFunc fn)
     {
         auto callback = std::make_unique<Utils::ContactCallback<Components...>>(std::move(fn));

--- a/src/plugin/physics/src/utils/ContactCallback.hpp
+++ b/src/plugin/physics/src/utils/ContactCallback.hpp
@@ -1,0 +1,61 @@
+#pragma once
+
+#include "Core.hpp"
+#include "Entity.hpp"
+#include "IContactCallback.hpp"
+
+#include <functional>
+
+namespace ES::Plugin::Physics::Utils {
+/**
+ * @brief A utility class for handling contact callbacks in a physics engine.
+ *
+ * @tparam Components The components to check for in the entities involved in the contact.
+ *
+ * @note Callbacks will be called with the Core, as well as the two entities that collided.
+ * @note The callback will be called once for each contact added.
+ * @note The callback will be called only if the entities have the specified components.
+ * @note If no components are specified, the callback will be called for all contacts.
+ * @note If one component is specified, the callback will be called only if both entities have that component.
+ * @note If two components are specified, the callback will be called only if one entity has the first component
+ * and the other entity has the second component.
+ */
+template<typename... Components>
+class ContactCallback : public IContactCallback {
+    public:
+        using CallbackFunc = std::function<void(ES::Engine::Core&, const ES::Engine::Entity&, const ES::Engine::Entity&)>;
+
+        ContactCallback(CallbackFunc cb) : callback(std::move(cb)) {}
+
+        void Call(ES::Engine::Core& core, const ES::Engine::Entity& a, const ES::Engine::Entity& b) const {
+            static_assert(sizeof...(Components) <= 2, "ContactCallback can only have up to 2 components.");
+
+            if constexpr (sizeof...(Components) == 0) {
+                callback(core, a, b);
+            } else if constexpr (sizeof...(Components) == 1) {
+                if (hasAllComponents<Components...>(core, a) && hasAllComponents<Components...>(core, b)) {
+                    callback(core, a, b);
+                }
+            } else if constexpr (sizeof...(Components) == 2) {
+                callIfComponentMatch<Components...>(core, a, b);
+            }
+        }
+
+    private:
+        CallbackFunc callback;
+
+        template<typename... Cs>
+        inline bool hasAllComponents(ES::Engine::Core& core, const ES::Engine::Entity& entity) const {
+            return ((entity.HasComponents<Cs>(core) && ...));
+        }
+
+        template<typename C1, typename C2>
+        void callIfComponentMatch(ES::Engine::Core& core, const ES::Engine::Entity& a, const ES::Engine::Entity& b) const {
+            if ((a.HasComponents<C1>(core) && b.HasComponents<C2>(core))) {
+                callback(core, a, b);
+            } else if ((a.HasComponents<C2>(core) && b.HasComponents<C1>(core))) {
+                callback(core, b, a);
+            }
+        }
+    };
+} // namespace ES::Plugin::Physics::Utils

--- a/src/plugin/physics/src/utils/ContactCallback.hpp
+++ b/src/plugin/physics/src/utils/ContactCallback.hpp
@@ -25,9 +25,9 @@ template <typename... Components> class ContactCallback : public IContactCallbac
     using CallbackFunc =
         std::function<void(ES::Engine::Core &, const ES::Engine::Entity &, const ES::Engine::Entity &)>;
 
-    ContactCallback(CallbackFunc cb) : callback(std::move(cb)) {}
+    explicit ContactCallback(CallbackFunc cb) : callback(std::move(cb)) {}
 
-    void Call(ES::Engine::Core &core, const ES::Engine::Entity &a, const ES::Engine::Entity &b) const
+    void Call(ES::Engine::Core &core, const ES::Engine::Entity &a, const ES::Engine::Entity &b) const final
     {
         static_assert(sizeof...(Components) <= 2, "ContactCallback can only have up to 2 components.");
 

--- a/src/plugin/physics/src/utils/ContactCallback.hpp
+++ b/src/plugin/physics/src/utils/ContactCallback.hpp
@@ -20,42 +20,54 @@ namespace ES::Plugin::Physics::Utils {
  * @note If two components are specified, the callback will be called only if one entity has the first component
  * and the other entity has the second component.
  */
-template<typename... Components>
-class ContactCallback : public IContactCallback {
-    public:
-        using CallbackFunc = std::function<void(ES::Engine::Core&, const ES::Engine::Entity&, const ES::Engine::Entity&)>;
+template <typename... Components> class ContactCallback : public IContactCallback {
+  public:
+    using CallbackFunc =
+        std::function<void(ES::Engine::Core &, const ES::Engine::Entity &, const ES::Engine::Entity &)>;
 
-        ContactCallback(CallbackFunc cb) : callback(std::move(cb)) {}
+    ContactCallback(CallbackFunc cb) : callback(std::move(cb)) {}
 
-        void Call(ES::Engine::Core& core, const ES::Engine::Entity& a, const ES::Engine::Entity& b) const {
-            static_assert(sizeof...(Components) <= 2, "ContactCallback can only have up to 2 components.");
+    void Call(ES::Engine::Core &core, const ES::Engine::Entity &a, const ES::Engine::Entity &b) const
+    {
+        static_assert(sizeof...(Components) <= 2, "ContactCallback can only have up to 2 components.");
 
-            if constexpr (sizeof...(Components) == 0) {
+        if constexpr (sizeof...(Components) == 0)
+        {
+            callback(core, a, b);
+        }
+        else if constexpr (sizeof...(Components) == 1)
+        {
+            if (hasAllComponents<Components...>(core, a) && hasAllComponents<Components...>(core, b))
+            {
                 callback(core, a, b);
-            } else if constexpr (sizeof...(Components) == 1) {
-                if (hasAllComponents<Components...>(core, a) && hasAllComponents<Components...>(core, b)) {
-                    callback(core, a, b);
-                }
-            } else if constexpr (sizeof...(Components) == 2) {
-                callIfComponentMatch<Components...>(core, a, b);
             }
         }
-
-    private:
-        CallbackFunc callback;
-
-        template<typename... Cs>
-        inline bool hasAllComponents(ES::Engine::Core& core, const ES::Engine::Entity& entity) const {
-            return ((entity.HasComponents<Cs>(core) && ...));
+        else if constexpr (sizeof...(Components) == 2)
+        {
+            callIfComponentMatch<Components...>(core, a, b);
         }
+    }
 
-        template<typename C1, typename C2>
-        void callIfComponentMatch(ES::Engine::Core& core, const ES::Engine::Entity& a, const ES::Engine::Entity& b) const {
-            if ((a.HasComponents<C1>(core) && b.HasComponents<C2>(core))) {
-                callback(core, a, b);
-            } else if ((a.HasComponents<C2>(core) && b.HasComponents<C1>(core))) {
-                callback(core, b, a);
-            }
+  private:
+    CallbackFunc callback;
+
+    template <typename... Cs>
+    inline bool hasAllComponents(ES::Engine::Core &core, const ES::Engine::Entity &entity) const
+    {
+        return ((entity.HasComponents<Cs>(core) && ...));
+    }
+
+    template <typename C1, typename C2>
+    void callIfComponentMatch(ES::Engine::Core &core, const ES::Engine::Entity &a, const ES::Engine::Entity &b) const
+    {
+        if ((a.HasComponents<C1>(core) && b.HasComponents<C2>(core)))
+        {
+            callback(core, a, b);
         }
-    };
+        else if ((a.HasComponents<C2>(core) && b.HasComponents<C1>(core)))
+        {
+            callback(core, b, a);
+        }
+    }
+};
 } // namespace ES::Plugin::Physics::Utils

--- a/src/plugin/physics/src/utils/ContactListenerImpl.cpp
+++ b/src/plugin/physics/src/utils/ContactListenerImpl.cpp
@@ -22,7 +22,7 @@ void ES::Plugin::Physics::Utils::ContactListenerImpl::OnContactAdded(const JPH::
 
     for (auto &callback : _onContactAddedCallbacks)
     {
-        callback(_core, entity1, entity2);
+        callback->Call(_core, entity1, entity2);
     }
 }
 
@@ -43,7 +43,7 @@ void ES::Plugin::Physics::Utils::ContactListenerImpl::OnContactPersisted(const J
 
     for (auto &callback : _onContactPersistedCallbacks)
     {
-        callback(_core, entity1, entity2);
+        callback->Call(_core, entity1, entity2);
     }
 }
 
@@ -72,6 +72,6 @@ void ES::Plugin::Physics::Utils::ContactListenerImpl::OnContactRemoved(const JPH
 
     for (auto &callback : _onContactRemovedCallbacks)
     {
-        callback(_core, entity1, entity2);
+        callback->Call(_core, entity1, entity2);
     }
 }

--- a/src/plugin/physics/src/utils/ContactListenerImpl.hpp
+++ b/src/plugin/physics/src/utils/ContactListenerImpl.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "Core.hpp"
+#include "ContactCallback.hpp"
+#include "IContactCallback.hpp"
 #include "Entity.hpp"
 
 // clang-format off
@@ -20,13 +22,6 @@ namespace ES::Plugin::Physics::Utils {
 // Callbacks will be called with the Core, as well as the two entities that collided.
 class ContactListenerImpl final : public JPH::ContactListener {
   public:
-    using OnContactAddedCallback =
-        std::function<void(ES::Engine::Core &, const ES::Engine::Entity &, const ES::Engine::Entity &)>;
-    using OnContactPersistedCallback =
-        std::function<void(ES::Engine::Core &, const ES::Engine::Entity &, const ES::Engine::Entity &)>;
-    using OnContactRemovedCallback =
-        std::function<void(ES::Engine::Core &, const ES::Engine::Entity &, const ES::Engine::Entity &)>;
-
     ContactListenerImpl() = delete;
 
     explicit ContactListenerImpl(ES::Engine::Core &core) : _core(core) {}
@@ -54,7 +49,8 @@ class ContactListenerImpl final : public JPH::ContactListener {
      * @note The callback will be called with the Core, as well as the two entities that collided.
      * @note The callback will be called once for each contact added.
      */
-    inline void AddOnContactAddedCallback(OnContactAddedCallback callback)
+    template<typename... Components>
+    inline void AddOnContactAddedCallback(std::unique_ptr<IContactCallback>&& callback)
     {
         _onContactAddedCallbacks.push_back(std::move(callback));
     }
@@ -66,7 +62,8 @@ class ContactListenerImpl final : public JPH::ContactListener {
      * @note The callback won't be called for the first collision.
      * @note The callback will be called every frame until the contact is removed.
      */
-    inline void AddOnContactPersistedCallback(OnContactPersistedCallback callback)
+    template<typename... Components>
+    inline void AddOnContactPersistedCallback(std::unique_ptr<IContactCallback>&& callback)
     {
         _onContactPersistedCallbacks.push_back(std::move(callback));
     }
@@ -77,7 +74,8 @@ class ContactListenerImpl final : public JPH::ContactListener {
      * @note The callback will be called with the Core, as well as the two entities that collided.
      * @note The callback will be called once for each contact removed.
      */
-    inline void AddOnContactRemovedCallback(OnContactRemovedCallback callback)
+    template<typename... Components>
+    inline void AddOnContactRemovedCallback(std::unique_ptr<IContactCallback>&& callback)
     {
         _onContactRemovedCallbacks.push_back(std::move(callback));
     }
@@ -85,8 +83,8 @@ class ContactListenerImpl final : public JPH::ContactListener {
   private:
     ES::Engine::Core &_core;
 
-    std::vector<OnContactAddedCallback> _onContactAddedCallbacks;
-    std::vector<OnContactPersistedCallback> _onContactPersistedCallbacks;
-    std::vector<OnContactRemovedCallback> _onContactRemovedCallbacks;
+    std::vector<std::unique_ptr<IContactCallback>> _onContactAddedCallbacks;
+    std::vector<std::unique_ptr<IContactCallback>> _onContactPersistedCallbacks;
+    std::vector<std::unique_ptr<IContactCallback>> _onContactRemovedCallbacks;
 };
 } // namespace ES::Plugin::Physics::Utils

--- a/src/plugin/physics/src/utils/ContactListenerImpl.hpp
+++ b/src/plugin/physics/src/utils/ContactListenerImpl.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
-#include "Core.hpp"
 #include "ContactCallback.hpp"
-#include "IContactCallback.hpp"
+#include "Core.hpp"
 #include "Entity.hpp"
+#include "IContactCallback.hpp"
 
 // clang-format off
 #include <Jolt/Jolt.h>
@@ -49,8 +49,8 @@ class ContactListenerImpl final : public JPH::ContactListener {
      * @note The callback will be called with the Core, as well as the two entities that collided.
      * @note The callback will be called once for each contact added.
      */
-    template<typename... Components>
-    inline void AddOnContactAddedCallback(std::unique_ptr<IContactCallback>&& callback)
+    template <typename... Components>
+    inline void AddOnContactAddedCallback(std::unique_ptr<IContactCallback> &&callback)
     {
         _onContactAddedCallbacks.push_back(std::move(callback));
     }
@@ -62,8 +62,8 @@ class ContactListenerImpl final : public JPH::ContactListener {
      * @note The callback won't be called for the first collision.
      * @note The callback will be called every frame until the contact is removed.
      */
-    template<typename... Components>
-    inline void AddOnContactPersistedCallback(std::unique_ptr<IContactCallback>&& callback)
+    template <typename... Components>
+    inline void AddOnContactPersistedCallback(std::unique_ptr<IContactCallback> &&callback)
     {
         _onContactPersistedCallbacks.push_back(std::move(callback));
     }
@@ -74,8 +74,8 @@ class ContactListenerImpl final : public JPH::ContactListener {
      * @note The callback will be called with the Core, as well as the two entities that collided.
      * @note The callback will be called once for each contact removed.
      */
-    template<typename... Components>
-    inline void AddOnContactRemovedCallback(std::unique_ptr<IContactCallback>&& callback)
+    template <typename... Components>
+    inline void AddOnContactRemovedCallback(std::unique_ptr<IContactCallback> &&callback)
     {
         _onContactRemovedCallbacks.push_back(std::move(callback));
     }

--- a/src/plugin/physics/src/utils/IContactCallback.hpp
+++ b/src/plugin/physics/src/utils/IContactCallback.hpp
@@ -20,6 +20,5 @@ class IContactCallback {
      * @param b The second entity.
      */
     virtual void Call(ES::Engine::Core &core, const ES::Engine::Entity &a, const ES::Engine::Entity &b) const = 0;
-
 };
 } // namespace ES::Plugin::Physics::Utils

--- a/src/plugin/physics/src/utils/IContactCallback.hpp
+++ b/src/plugin/physics/src/utils/IContactCallback.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "Core.hpp"
+#include "Entity.hpp"
+
+namespace ES::Plugin::Physics::Utils {
+/**
+ * @brief Type erased contact callback.
+ *
+ * @note This should not be constructed directly, use the ContactCallback class instead.
+ */
+class IContactCallback {
+  public:
+    virtual ~IContactCallback() = default;
+
+    /**
+     * @brief Call the callback with the given core and entities.
+     * @param core The core to use.
+     * @param a The first entity.
+     * @param b The second entity.
+     */
+    virtual void Call(ES::Engine::Core &core, const ES::Engine::Entity &a, const ES::Engine::Entity &b) const = 0;
+
+};
+} // namespace ES::Plugin::Physics::Utils


### PR DESCRIPTION
In #164 we have discussed the ability to add callbacks only if entities had certain components. This PR implements it

If you want to know how callbacks are handled, I have added documentation in the code. but in short:
- No components: callbacks are always called 
- One component: callbacks are called only if the two entities have the component
- Two component: callbacks are called if entity 1 has the first component and entity 2 has the second component

Notes: 
- when using callbacks with two components needed, the entities will be reordered if needed to match the order of the callback
- the Entity method "HasComponents" is now const (we don't modify the entity so it should be)

Test in RollingBall with something like this:
```cpp
core.RegisterSystem<ES::Engine::Scheduler::Startup>(
		[](ES::Engine::Core &c) {
			c.GetResource<ES::Plugin::Physics::Resource::PhysicsManager>().AddContactAddedCallback(
				[](const ES::Engine::Core &cbCore, const ES::Engine::Entity &a, const ES::Engine::Entity &b) {
					printf("Contact added between entities %d and %d\n", a, b);
				}
			);
			c.GetResource<ES::Plugin::Physics::Resource::PhysicsManager>().AddContactAddedCallback<ES::Plugin::Object::Component::Transform>(
				[](const ES::Engine::Core &cbCore, const ES::Engine::Entity &a, const ES::Engine::Entity &b) {
					printf("Contact added between entities with transform %d and %d\n", a, b);
				}
			);
			c.GetResource<ES::Plugin::Physics::Resource::PhysicsManager>().AddContactAddedCallback<Game::Player, Game::Terrain>(
				[](const ES::Engine::Core &cbCore, const ES::Engine::Entity &a, const ES::Engine::Entity &b) {
					printf("Contact added between player %d and terrain %d\n", a, b);
				}
			);
		}
	);
```