### PR TITLE
refactor: remove const from contact callbacks

### DIFF
--- a/src/plugin/physics/src/utils/ContactCallback.hpp
+++ b/src/plugin/physics/src/utils/ContactCallback.hpp
@@ -22,8 +22,7 @@ namespace ES::Plugin::Physics::Utils {
  */
 template <typename... Components> class ContactCallback : public IContactCallback {
   public:
-    using CallbackFunc =
-        std::function<void(ES::Engine::Core &, ES::Engine::Entity &, ES::Engine::Entity &)>;
+    using CallbackFunc = std::function<void(ES::Engine::Core &, ES::Engine::Entity &, ES::Engine::Entity &)>;
 
     explicit ContactCallback(CallbackFunc cb) : callback(std::move(cb)) {}
 

--- a/src/plugin/physics/src/utils/ContactCallback.hpp
+++ b/src/plugin/physics/src/utils/ContactCallback.hpp
@@ -23,11 +23,11 @@ namespace ES::Plugin::Physics::Utils {
 template <typename... Components> class ContactCallback : public IContactCallback {
   public:
     using CallbackFunc =
-        std::function<void(ES::Engine::Core &, const ES::Engine::Entity &, const ES::Engine::Entity &)>;
+        std::function<void(ES::Engine::Core &, ES::Engine::Entity &, ES::Engine::Entity &)>;
 
     explicit ContactCallback(CallbackFunc cb) : callback(std::move(cb)) {}
 
-    void Call(ES::Engine::Core &core, const ES::Engine::Entity &a, const ES::Engine::Entity &b) const final
+    void Call(ES::Engine::Core &core, ES::Engine::Entity &a, ES::Engine::Entity &b) const final
     {
         static_assert(sizeof...(Components) <= 2, "ContactCallback can only have up to 2 components.");
 
@@ -58,7 +58,7 @@ template <typename... Components> class ContactCallback : public IContactCallbac
     }
 
     template <typename C1, typename C2>
-    void callIfComponentMatch(ES::Engine::Core &core, const ES::Engine::Entity &a, const ES::Engine::Entity &b) const
+    void callIfComponentMatch(ES::Engine::Core &core, ES::Engine::Entity &a, ES::Engine::Entity &b) const
     {
         if ((a.HasComponents<C1>(core) && b.HasComponents<C2>(core)))
         {

--- a/src/plugin/physics/src/utils/IContactCallback.hpp
+++ b/src/plugin/physics/src/utils/IContactCallback.hpp
@@ -19,6 +19,6 @@ class IContactCallback {
      * @param a The first entity.
      * @param b The second entity.
      */
-    virtual void Call(ES::Engine::Core &core, const ES::Engine::Entity &a, const ES::Engine::Entity &b) const = 0;
+    virtual void Call(ES::Engine::Core &core, ES::Engine::Entity &a, ES::Engine::Entity &b) const = 0;
 };
 } // namespace ES::Plugin::Physics::Utils


### PR DESCRIPTION
Kinda dumb to use const references because in most use cases we actually want to modify some components when a collision happens

Previously we had to use the core (because it isn't const) like this:
```cpp
auto &playerComponent = core.GetRegistry().get<Game::Player>(player);
```
Now we can just do this:
```cpp
auto &playerComponent = player.GetComponents<Game::Player>(core);
```