### PR TITLE
feat(OpenGL): update viewport and camera when resizing

### DIFF
--- a/src/plugin/opengl/src/plugin/PluginOpenGL.cpp
+++ b/src/plugin/opengl/src/plugin/PluginOpenGL.cpp
@@ -17,6 +17,8 @@ void ES::Plugin::OpenGL::Plugin::Bind()
     RegisterSystems<ES::Engine::Scheduler::Startup>(ES::Plugin::Window::System::EnableVSync);
     RegisterSystems<ES::Engine::Scheduler::Startup>(ES::Plugin::Window::System::LoadButtons);
 
+    RegisterSystems<ES::Engine::Scheduler::Startup>(ES::Plugin::OpenGL::System::SetupResizeViewport);
+
     RegisterSystems<ES::Engine::Scheduler::Startup>(ES::Plugin::OpenGL::System::LoadFontManager);
     RegisterSystems<ES::Engine::Scheduler::Startup>(ES::Plugin::OpenGL::System::LoadMaterialCache);
     RegisterSystems<ES::Engine::Scheduler::Startup>(ES::Plugin::OpenGL::System::LoadShaderManager);

--- a/src/plugin/opengl/src/system/AllSystems.cpp
+++ b/src/plugin/opengl/src/system/AllSystems.cpp
@@ -50,7 +50,8 @@ void ES::Plugin::OpenGL::System::SetupResizeViewport(ES::Engine::Core &core)
     core.GetResource<Window::Resource::Window>().SetFramebufferSizeCallback(
         &core, [](GLFWwindow *window, int width, int height) {
             auto &c = *static_cast<ES::Engine::Core *>(glfwGetWindowUserPointer(window));
-            c.GetResource<OpenGL::Resource::Camera>().viewer.setAspectRatio(static_cast<float>(width) / static_cast<float>(height));
+            c.GetResource<OpenGL::Resource::Camera>().viewer.setAspectRatio(static_cast<float>(width) /
+                                                                            static_cast<float>(height));
             c.GetResource<Resource::Camera>().size = glm::vec2(width, height);
             glViewport(0, 0, width, height);
         });

--- a/src/plugin/opengl/src/system/AllSystems.cpp
+++ b/src/plugin/opengl/src/system/AllSystems.cpp
@@ -20,6 +20,7 @@
 #include "SpriteHandle.hpp"
 #include "Text.hpp"
 #include "TextHandle.hpp"
+#include "Window.hpp"
 
 #include <glm/gtc/type_ptr.hpp>
 #include <iostream>
@@ -42,6 +43,17 @@ void ES::Plugin::OpenGL::System::CheckGLEWVersion(const ES::Engine::Core &)
         return;
     }
     ES::Utils::Log::Info("OpenGL 4.2 supported");
+}
+
+void ES::Plugin::OpenGL::System::SetupResizeViewport(ES::Engine::Core &core)
+{
+    core.GetResource<Window::Resource::Window>().SetFramebufferSizeCallback(
+        &core, [](GLFWwindow *window, int width, int height) {
+            auto &c = *static_cast<ES::Engine::Core *>(glfwGetWindowUserPointer(window));
+            c.GetResource<OpenGL::Resource::Camera>().viewer.setAspectRatio(static_cast<float>(width) / static_cast<float>(height));
+            c.GetResource<Resource::Camera>().size = glm::vec2(width, height);
+            glViewport(0, 0, width, height);
+        });
 }
 
 // Function to handle mouse dragging interactions

--- a/src/plugin/opengl/src/system/AllSystems.hpp
+++ b/src/plugin/opengl/src/system/AllSystems.hpp
@@ -10,6 +10,8 @@ void InitGLEW(const ES::Engine::Core &core);
 
 void CheckGLEWVersion(const ES::Engine::Core &core);
 
+void SetupResizeViewport(ES::Engine::Core &core);
+
 void MouseDragging(ES::Engine::Core &core);
 
 void LoadFontManager(ES::Engine::Core &core);


### PR DESCRIPTION
This PR add a new callback when resizing the framebuffer (window) that update OpenGL viewport and camera size and aspect ratio.

Example:

![image](https://github.com/user-attachments/assets/49c9b951-1498-4837-882e-802b3ed7523d)
![image](https://github.com/user-attachments/assets/60520b09-f50d-4c7d-898b-383bab9cc1a1)
