### PR TITLE
feat(Window): add toggle for fullscreen

### DIFF
--- a/src/plugin/window/src/resource/Window/Window.hpp
+++ b/src/plugin/window/src/resource/Window/Window.hpp
@@ -77,28 +77,26 @@ class Window {
 
     void ToggleFullscreen()
     {
-        if (!_window) return;
+        if (!_window)
+            return;
 
-        if (!_isFullscreen) {
+        if (!_isFullscreen)
+        {
             // Save windowed position and size
             glfwGetWindowPos(_window, &_windowedX, &_windowedY);
             glfwGetWindowSize(_window, &_windowedWidth, &_windowedHeight);
 
             // Get primary monitor and video mode
             _monitor = glfwGetPrimaryMonitor();
-            const GLFWvidmode* mode = glfwGetVideoMode(_monitor);
+            const GLFWvidmode *mode = glfwGetVideoMode(_monitor);
 
             // Switch to fullscreen
-            glfwSetWindowMonitor(_window, _monitor,
-                                0, 0,
-                                mode->width, mode->height,
-                                mode->refreshRate);
-        } else {
+            glfwSetWindowMonitor(_window, _monitor, 0, 0, mode->width, mode->height, mode->refreshRate);
+        }
+        else
+        {
             // Restore windowed mode
-            glfwSetWindowMonitor(_window, nullptr,
-                                _windowedX, _windowedY,
-                                _windowedWidth, _windowedHeight,
-                                0);
+            glfwSetWindowMonitor(_window, nullptr, _windowedX, _windowedY, _windowedWidth, _windowedHeight, 0);
         }
 
         _isFullscreen = !_isFullscreen;

--- a/src/plugin/window/src/resource/Window/Window.hpp
+++ b/src/plugin/window/src/resource/Window/Window.hpp
@@ -30,6 +30,10 @@ class Window {
     GLFWmonitor *_monitor;
     GLFWwindow *_share;
 
+    bool _isFullscreen = false;
+    int _windowedX = 0, _windowedY = 0;
+    int _windowedWidth = 0, _windowedHeight = 0;
+
   public:
     Window(uint32_t width, uint32_t height, const std::string &title, GLFWmonitor *monitor = nullptr,
            GLFWwindow *share = nullptr);
@@ -70,6 +74,35 @@ class Window {
      * @param callback The callback function.
      */
     void SetFramebufferSizeCallback(void *userPointer, GLFWframebuffersizefun callback);
+
+    void ToggleFullscreen()
+    {
+        if (!_window) return;
+
+        if (!_isFullscreen) {
+            // Save windowed position and size
+            glfwGetWindowPos(_window, &_windowedX, &_windowedY);
+            glfwGetWindowSize(_window, &_windowedWidth, &_windowedHeight);
+
+            // Get primary monitor and video mode
+            _monitor = glfwGetPrimaryMonitor();
+            const GLFWvidmode* mode = glfwGetVideoMode(_monitor);
+
+            // Switch to fullscreen
+            glfwSetWindowMonitor(_window, _monitor,
+                                0, 0,
+                                mode->width, mode->height,
+                                mode->refreshRate);
+        } else {
+            // Restore windowed mode
+            glfwSetWindowMonitor(_window, nullptr,
+                                _windowedX, _windowedY,
+                                _windowedWidth, _windowedHeight,
+                                0);
+        }
+
+        _isFullscreen = !_isFullscreen;
+    }
 };
 
 } // namespace ES::Plugin::Window::Resource


### PR DESCRIPTION
I added a way to toggle fullscreen.

You can find a little demo here:
https://github.com/EngineSquared/Rolling-Ball/pull/16

You just have to click on the middle button (options) and on the square to activate/desactivate fullscreen.