### PR TITLE
fix(OpenGL): make "updated" bool in mouse button works properly

### DIFF
--- a/src/plugin/window/src/system/WindowSystem.cpp
+++ b/src/plugin/window/src/system/WindowSystem.cpp
@@ -27,8 +27,8 @@ void UpdateButton(ES::Engine::Core &core)
     for (auto &[key, button] : mouseButtons)
     {
         bool pressed = glfwGetMouseButton(window, key) == GLFW_PRESS;
-        button.pressed = pressed;
         button.updated = button.pressed != pressed;
+        button.pressed = pressed;
     }
 }
 


### PR DESCRIPTION
I fixed the "updated" state of buttons.

Before, `button.pressed` and `pressed` was always the same because we assign each other just before, but it should be done just after.