### PR TITLE
feat(OpenGL): allow putting texture on sprites

### DIFF
--- a/src/plugin/opengl/src/system/AllSystems.cpp
+++ b/src/plugin/opengl/src/system/AllSystems.cpp
@@ -519,6 +519,11 @@ void ES::Plugin::OpenGL::System::RenderSprites(ES::Engine::Core &core)
                                glm::value_ptr(transform.getTransformationMatrix()));
             glUniformMatrix4fv(shader.uniform("projection"), 1, GL_FALSE, glm::value_ptr(projection));
 
+            Component::TextureHandle *textureHandle =
+                ES::Engine::Entity(e).TryGetComponent<Component::TextureHandle>(core);
+            if (textureHandle)
+                core.GetResource<Resource::TextureManager>().Get(textureHandle->id).Bind();
+
             glBuffer.Draw();
             shader.disable();
         });

--- a/src/plugin/opengl/src/utils/GLSpriteBuffer/GLSpriteBuffer.cpp
+++ b/src/plugin/opengl/src/utils/GLSpriteBuffer/GLSpriteBuffer.cpp
@@ -39,7 +39,7 @@ void GLSpriteBuffer::GenerateGLSpriteBuffers(const Component::Sprite &sprite) no
     // Vertex Texture Coordinates VBO
     glGenBuffers(1, &VBO_texCoords);
     glBindBuffer(GL_ARRAY_BUFFER, VBO_texCoords);
-    glBufferData(GL_ARRAY_BUFFER,  sizeof(texCoords), texCoords.data(), GL_STATIC_DRAW);
+    glBufferData(GL_ARRAY_BUFFER, sizeof(texCoords), texCoords.data(), GL_STATIC_DRAW);
     glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, sizeof(glm::vec2), nullptr);
     glEnableVertexAttribArray(1);
 

--- a/src/plugin/opengl/src/utils/GLSpriteBuffer/GLSpriteBuffer.cpp
+++ b/src/plugin/opengl/src/utils/GLSpriteBuffer/GLSpriteBuffer.cpp
@@ -28,6 +28,21 @@ void GLSpriteBuffer::GenerateGLSpriteBuffers(const Component::Sprite &sprite) no
     glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(glm::vec3), nullptr);
     glEnableVertexAttribArray(0);
 
+    // texture coordinates VBO
+    std::array<glm::vec2, 4> texCoords = {
+        glm::vec2{0.f, 1.f},
+        glm::vec2{1.f, 1.f},
+        glm::vec2{0.f, 0.f},
+        glm::vec2{1.f, 0.f}
+    };
+
+    // Vertex Texture Coordinates VBO
+    glGenBuffers(1, &VBO_texCoords);
+    glBindBuffer(GL_ARRAY_BUFFER, VBO_texCoords);
+    glBufferData(GL_ARRAY_BUFFER,  sizeof(texCoords), texCoords.data(), GL_STATIC_DRAW);
+    glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, sizeof(glm::vec2), nullptr);
+    glEnableVertexAttribArray(1);
+
     // Element indices buffer
     std::array<unsigned int, 6> indices = {2, 0, 1, 2, 1, 3};
     glGenBuffers(1, &IBO);

--- a/src/plugin/opengl/src/utils/GLSpriteBuffer/GLSpriteBuffer.hpp
+++ b/src/plugin/opengl/src/utils/GLSpriteBuffer/GLSpriteBuffer.hpp
@@ -51,6 +51,7 @@ class GLSpriteBuffer {
     GLuint VAO = 0;
     GLuint VBO = 0;
     GLuint IBO = 0;
+    GLuint VBO_texCoords = 0;
 };
 
 } // namespace ES::Plugin::OpenGL::Utils


### PR DESCRIPTION
As we have texture on mesh, this PR will allows to put texture on sprites

You can check it [here](https://github.com/EngineSquared/Rolling-Ball). Warning, [this pr](https://github.com/EngineSquared/EngineSquared/pull/188) will fix the ugly pixel displacement :) AND you will also change the color of the button if [this PR](https://github.com/EngineSquared/EngineSquared/pull/187) is not merged