### PR TITLE
fix: use bottom-left format for return value of GetMousePosition

### DIFF
--- a/src/plugin/input/src/resource/InputManager.hpp
+++ b/src/plugin/input/src/resource/InputManager.hpp
@@ -32,18 +32,5 @@ class InputManager {
     {
         return glfwGetMouseButton(glfwGetCurrentContext(), button) == GLFW_PRESS;
     }
-
-    /**
-     * @brief Get the current mouse position.
-     *
-     * @return A pair containing the x and y coordinates of the mouse.
-     */
-    inline glm::vec2 GetMousePosition()
-    {
-        double x;
-        double y;
-        glfwGetCursorPos(glfwGetCurrentContext(), &x, &y);
-        return {x, y};
-    }
 };
 } // namespace ES::Plugin::Input::Resource

--- a/src/plugin/ui/src/system/UpdateButtonState.cpp
+++ b/src/plugin/ui/src/system/UpdateButtonState.cpp
@@ -13,12 +13,9 @@
 void ES::Plugin::UI::System::UpdateButtonState(ES::Engine::Core &core)
 {
     auto &inputManager = core.GetResource<ES::Plugin::Input::Resource::InputManager>();
+    auto &window = core.GetResource<ES::Plugin::Window::Resource::Window>();
     const bool &isMouseLeftPressed = inputManager.IsMouseButtonPressed(GLFW_MOUSE_BUTTON_LEFT);
-    int width = 0;
-    int height = 0;
-    core.GetResource<ES::Plugin::Window::Resource::Window>().GetWindowSize(width, height);
-    glm::vec2 mousePos = inputManager.GetMousePosition();
-    mousePos.y = height - mousePos.y; // Invert Y axis to match the window coordinates
+    glm::vec2 mousePos = window.GetMousePosition();
     auto view = core.GetRegistry()
                     .view<ES::Plugin::UI::Component::Button, ES::Plugin::UI::Component::BoxCollider2D,
                           ES::Plugin::Object::Component::Transform>();

--- a/src/plugin/window/src/resource/Window/Window.hpp
+++ b/src/plugin/window/src/resource/Window/Window.hpp
@@ -2,9 +2,9 @@
 
 #include <string>
 
-#include <stdexcept>
 #include <GLFW/glfw3.h>
 #include <glm/vec2.hpp>
+#include <stdexcept>
 
 #include "WindowError.hpp"
 

--- a/src/plugin/window/src/resource/Window/Window.hpp
+++ b/src/plugin/window/src/resource/Window/Window.hpp
@@ -2,8 +2,9 @@
 
 #include <string>
 
-#include <GLFW/glfw3.h>
 #include <stdexcept>
+#include <GLFW/glfw3.h>
+#include <glm/vec2.hpp>
 
 #include "WindowError.hpp"
 
@@ -91,6 +92,23 @@ class Window {
     void SetSize(int width, int height);
 
     void ToggleFullscreen();
+
+    /**
+     * @brief Get the current mouse position.
+     *
+     * @return A pair containing the x and y coordinates of the mouse.
+     */
+    inline glm::vec2 GetMousePosition()
+    {
+        int width = 0;
+        int height = 0;
+        double x = 0;
+        double y = 0;
+        this->GetWindowSize(width, height);
+        glfwGetCursorPos(_window, &x, &y);
+        y = height - y;
+        return {x, y};
+    }
 };
 
 } // namespace ES::Plugin::Window::Resource


### PR DESCRIPTION
Related to:
- #162 

I moved this function into Window class because we want to get the glfw window and it would be not convenient to send core or Window class into the method 