### PR TITLE
feat(log): display entity ids with index and version

### DIFF
--- a/src/engine/src/entity/Entity.hpp
+++ b/src/engine/src/entity/Entity.hpp
@@ -6,7 +6,7 @@
 #include <typeindex>
 
 #ifdef ES_DEBUG
-#include "EntityToIDString.hpp"
+#    include "EntityToIDString.hpp"
 #endif
 
 namespace ES::Engine {
@@ -47,7 +47,8 @@ class Entity {
     {
         Entity entity = core.CreateEntity();
 #ifdef ES_DEBUG
-        ES::Utils::Log::Info(fmt::format("[EntityID:{}] Create Entity", ES::Utils::Log::EntityToDebugString(entity_id_type(entity))));
+        ES::Utils::Log::Info(
+            fmt::format("[EntityID:{}] Create Entity", ES::Utils::Log::EntityToDebugString(entity_id_type(entity))));
 #endif
         return entity;
     }
@@ -94,7 +95,8 @@ class Entity {
     template <typename TComponent> inline decltype(auto) AddComponent(Core &core, TComponent &&component)
     {
 #ifdef ES_DEBUG
-        ES::Utils::Log::Info(fmt::format("[EntityID:{}] AddComponent: {}", ES::Utils::Log::EntityToDebugString(_entity), typeid(TComponent).name()));
+        ES::Utils::Log::Info(fmt::format("[EntityID:{}] AddComponent: {}", ES::Utils::Log::EntityToDebugString(_entity),
+                                         typeid(TComponent).name()));
 #endif
         return core.GetRegistry().emplace<TComponent>(ToEnttEntity(this->_entity), std::forward<TComponent>(component));
     }
@@ -111,7 +113,8 @@ class Entity {
     template <typename TComponent, typename... TArgs> inline decltype(auto) AddComponent(Core &core, TArgs &&...args)
     {
 #ifdef ES_DEBUG
-        ES::Utils::Log::Info(fmt::format("[EntityID:{}] AddComponent: {}", ES::Utils::Log::EntityToDebugString(_entity), typeid(TComponent).name()));
+        ES::Utils::Log::Info(fmt::format("[EntityID:{}] AddComponent: {}", ES::Utils::Log::EntityToDebugString(_entity),
+                                         typeid(TComponent).name()));
 #endif
         return core.GetRegistry().emplace<TComponent>(ToEnttEntity(this->_entity), std::forward<TArgs>(args)...);
     }
@@ -191,7 +194,8 @@ class Entity {
     template <typename TComponent> inline void RemoveComponent(Core &core)
     {
 #ifdef ES_DEBUG
-        ES::Utils::Log::Info(fmt::format("[EntityID:{}] RemoveComponent: {}", ES::Utils::Log::EntityToDebugString(_entity), typeid(TComponent).name()));
+        ES::Utils::Log::Info(fmt::format("[EntityID:{}] RemoveComponent: {}",
+                                         ES::Utils::Log::EntityToDebugString(_entity), typeid(TComponent).name()));
 #endif
         core.GetRegistry().remove<TComponent>(ToEnttEntity(this->_entity));
     }

--- a/src/engine/src/entity/Entity.hpp
+++ b/src/engine/src/entity/Entity.hpp
@@ -5,6 +5,10 @@
 #include <entt/entt.hpp>
 #include <typeindex>
 
+#ifdef ES_DEBUG
+#include "EntityToIDString.hpp"
+#endif
+
 namespace ES::Engine {
 /**
  * Contains a single value which must correspond to an index in a registry.
@@ -43,7 +47,7 @@ class Entity {
     {
         Entity entity = core.CreateEntity();
 #ifdef ES_DEBUG
-        ES::Utils::Log::Info(fmt::format("[EntityID:{}] Create Entity", entity_id_type(entity)));
+        ES::Utils::Log::Info(fmt::format("[EntityID:{}] Create Entity", ES::Utils::Log::EntityToDebugString(entity_id_type(entity))));
 #endif
         return entity;
     }
@@ -57,7 +61,7 @@ class Entity {
     void Destroy(Core &core)
     {
 #ifdef ES_DEBUG
-        ES::Utils::Log::Info(fmt::format("[EntityID:{}] Destroy Entity", _entity));
+        ES::Utils::Log::Info(fmt::format("[EntityID:{}] Destroy Entity", ES::Utils::Log::EntityToDebugString(_entity)));
 #endif
         core.KillEntity(*this);
     }
@@ -90,7 +94,7 @@ class Entity {
     template <typename TComponent> inline decltype(auto) AddComponent(Core &core, TComponent &&component)
     {
 #ifdef ES_DEBUG
-        ES::Utils::Log::Info(fmt::format("[EntityID:{}] AddComponent: {}", _entity, typeid(TComponent).name()));
+        ES::Utils::Log::Info(fmt::format("[EntityID:{}] AddComponent: {}", ES::Utils::Log::EntityToDebugString(_entity), typeid(TComponent).name()));
 #endif
         return core.GetRegistry().emplace<TComponent>(ToEnttEntity(this->_entity), std::forward<TComponent>(component));
     }
@@ -107,7 +111,7 @@ class Entity {
     template <typename TComponent, typename... TArgs> inline decltype(auto) AddComponent(Core &core, TArgs &&...args)
     {
 #ifdef ES_DEBUG
-        ES::Utils::Log::Info(fmt::format("[EntityID:{}] AddComponent: {}", _entity, typeid(TComponent).name()));
+        ES::Utils::Log::Info(fmt::format("[EntityID:{}] AddComponent: {}", ES::Utils::Log::EntityToDebugString(_entity), typeid(TComponent).name()));
 #endif
         return core.GetRegistry().emplace<TComponent>(ToEnttEntity(this->_entity), std::forward<TArgs>(args)...);
     }
@@ -187,7 +191,7 @@ class Entity {
     template <typename TComponent> inline void RemoveComponent(Core &core)
     {
 #ifdef ES_DEBUG
-        ES::Utils::Log::Info(fmt::format("[EntityID:{}] RemoveComponent: {}", _entity, typeid(TComponent).name()));
+        ES::Utils::Log::Info(fmt::format("[EntityID:{}] RemoveComponent: {}", ES::Utils::Log::EntityToDebugString(_entity), typeid(TComponent).name()));
 #endif
         core.GetRegistry().remove<TComponent>(ToEnttEntity(this->_entity));
     }

--- a/src/utils/log/src/EntityToIDString.hpp
+++ b/src/utils/log/src/EntityToIDString.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <string>
+#include <fmt/format.h>
+#include <bit>
+
+namespace ES::Utils::Log {
+template<typename T>
+inline std::string EntityToDebugString(const T &entity)
+{
+    return fmt::format("({}, {})", entity & 0x000FFFFF, entity >> 20);
+}
+}

--- a/src/utils/log/src/EntityToIDString.hpp
+++ b/src/utils/log/src/EntityToIDString.hpp
@@ -5,8 +5,18 @@
 #include <string>
 
 namespace ES::Utils::Log {
+template <typename T> inline T GetEntityIndex(const T &entity)
+{
+    return entity & 0x000FFFFF;
+}
+
+template <typename T> inline T GetEntityVersion(const T &entity)
+{
+    return entity >> 20;
+}
+
 template <typename T> inline std::string EntityToDebugString(const T &entity)
 {
-    return fmt::format("({}, {})", entity & 0x000FFFFF, entity >> 20);
+    return fmt::format("({}, {})", GetEntityIndex(entity), GetEntityVersion(entity));
 }
 } // namespace ES::Utils::Log

--- a/src/utils/log/src/EntityToIDString.hpp
+++ b/src/utils/log/src/EntityToIDString.hpp
@@ -5,15 +5,9 @@
 #include <string>
 
 namespace ES::Utils::Log {
-template <typename T> inline T GetEntityIndex(const T &entity)
-{
-    return entity & 0x000FFFFF;
-}
+template <typename T> inline T GetEntityIndex(const T &entity) { return entity & 0x000FFFFF; }
 
-template <typename T> inline T GetEntityVersion(const T &entity)
-{
-    return entity >> 20;
-}
+template <typename T> inline T GetEntityVersion(const T &entity) { return entity >> 20; }
 
 template <typename T> inline std::string EntityToDebugString(const T &entity)
 {

--- a/src/utils/log/src/EntityToIDString.hpp
+++ b/src/utils/log/src/EntityToIDString.hpp
@@ -1,13 +1,12 @@
 #pragma once
 
-#include <string>
-#include <fmt/format.h>
 #include <bit>
+#include <fmt/format.h>
+#include <string>
 
 namespace ES::Utils::Log {
-template<typename T>
-inline std::string EntityToDebugString(const T &entity)
+template <typename T> inline std::string EntityToDebugString(const T &entity)
 {
     return fmt::format("({}, {})", entity & 0x000FFFFF, entity >> 20);
 }
-}
+} // namespace ES::Utils::Log

--- a/src/utils/log/xmake.lua
+++ b/src/utils/log/xmake.lua
@@ -1,9 +1,9 @@
 add_rules("mode.debug", "mode.release")
-add_requires("spdlog")
+add_requires("spdlog", "fmt")
 set_languages("cxx20")
 
 target("UtilsLog")
     set_kind("static")
-    add_packages("spdlog")
+    add_packages("spdlog", "fmt")
 
     add_includedirs("src/", {public = true})


### PR DESCRIPTION
Related to:
- #204 

Entities IDs are now displayed with their index and version. If an entity index is reused but the entity has a different version, it will be shown on logs. This was made to reduce clutter in logs

On this example: the entity at index 0 was destroyed and then reused
![image](https://github.com/user-attachments/assets/25a3d526-0483-45b1-9a2d-3b793f25b25c)
