### PR TITLE
fix(Sound): missing fmt dependency in xmake

### DIFF
--- a/src/plugin/sound/xmake.lua
+++ b/src/plugin/sound/xmake.lua
@@ -1,12 +1,12 @@
 add_rules("mode.debug", "mode.release")
-add_requires("miniaudio", "entt", "spdlog")
+add_requires("miniaudio", "entt", "spdlog", "fmt")
 
 includes("../../engine/xmake.lua")
 
 target("PluginSound")
     set_kind("static")
     set_languages("cxx20")
-    add_packages("miniaudio", "entt", "spdlog")
+    add_packages("miniaudio", "entt", "spdlog", "fmt")
     set_policy("build.warning", true)
 
     add_deps("EngineSquaredCore")


### PR DESCRIPTION
Not related to any issue

The engine won't compile due to missing `fmt` dependency in the sound plugin xmake