### PR TITLE
feat(Core): add dependency between startup, shutdown and fixed and relative update

### DIFF
--- a/src/engine/src/core/Core.cpp
+++ b/src/engine/src/core/Core.cpp
@@ -17,6 +17,14 @@ ES::Engine::Core::Core() : _registry(nullptr)
     this->RegisterScheduler<ES::Engine::Scheduler::FixedTimeUpdate>();
     this->RegisterScheduler<ES::Engine::Scheduler::RelativeTimeUpdate>();
     this->RegisterScheduler<ES::Engine::Scheduler::Shutdown>();
+
+    this->SetSchedulerBefore<ES::Engine::Scheduler::Startup, ES::Engine::Scheduler::Update>();
+    this->SetSchedulerBefore<ES::Engine::Scheduler::Startup, ES::Engine::Scheduler::FixedTimeUpdate>();
+    this->SetSchedulerBefore<ES::Engine::Scheduler::Startup, ES::Engine::Scheduler::RelativeTimeUpdate>();
+    this->SetSchedulerAfter<ES::Engine::Scheduler::Shutdown, ES::Engine::Scheduler::Update>();
+    this->SetSchedulerAfter<ES::Engine::Scheduler::Shutdown, ES::Engine::Scheduler::FixedTimeUpdate>();
+    this->SetSchedulerAfter<ES::Engine::Scheduler::Shutdown, ES::Engine::Scheduler::RelativeTimeUpdate>();
+
 }
 
 ES::Engine::Core::~Core() { ES::Utils::Log::Debug("Destroy Core"); }

--- a/src/engine/src/core/Core.hpp
+++ b/src/engine/src/core/Core.hpp
@@ -99,14 +99,53 @@ class Core {
      */
     template <CScheduler TScheduler> TScheduler &GetScheduler();
 
+    
+    /**
+     * @brief Sets the execution order of two schedulers, ensuring that TSchedulerA
+     *        is executed before TSchedulerB.
+     * 
+     * @tparam TSchedulerA The type of the scheduler that should execute first.
+     * @tparam TSchedulerB The type of the scheduler that should execute after TSchedulerA.
+     */
     template <typename TSchedulerA, typename TSchedulerB> inline void SetSchedulerBefore()
     {
         this->_schedulers.Before<TSchedulerA, TSchedulerB>();
     }
 
+    /**
+     * @brief Sets the execution order of two schedulers by specifying that one scheduler
+     *        should execute after another.
+     * 
+     * @tparam TSchedulerA The type of the scheduler that should execute first.
+     * @tparam TSchedulerB The type of the scheduler that should execute after TSchedulerA.
+     */
     template <typename TSchedulerA, typename TSchedulerB> inline void SetSchedulerAfter()
     {
         this->_schedulers.After<TSchedulerA, TSchedulerB>();
+    }
+
+    /**
+     * @brief Removes a dependency between two schedulers, ensuring that TSchedulerB
+     *        is no longer dependent on TSchedulerA.
+     * 
+     * @tparam TSchedulerA The type of the first scheduler (the one being depended on).
+     * @tparam TSchedulerB The type of the second scheduler (the one depending on TSchedulerA).
+     */
+    template <typename TSchedulerA, typename TSchedulerB> inline void RemoveDependencyAfter()
+    {
+        this->_schedulers.RemoveDependencyAfter<TSchedulerA, TSchedulerB>();
+    }
+
+    /**
+     * @brief Removes a dependency between two schedulers, ensuring that TSchedulerA
+     *       is no longer dependent on TSchedulerB.
+     * 
+     * @tparam TSchedulerA The type of the first scheduler (the one depending on TSchedulerB).
+     * @tparam TSchedulerB The type of the second scheduler (the one being depended on).
+     */
+    template <typename TSchedulerA, typename TSchedulerB> inline void RemoveDependencyBefore()
+    {
+        this->_schedulers.RemoveDependencyBefore<TSchedulerA, TSchedulerB>();
     }
 
     /**

--- a/src/engine/src/scheduler/SchedulerContainer.hpp
+++ b/src/engine/src/scheduler/SchedulerContainer.hpp
@@ -134,6 +134,29 @@ class SchedulerContainer {
      * exists in the container. It returns true if the scheduler is found,
      * otherwise false.
      *
+     * @tparam TScheduler The type of the scheduler to check for.
+     * @return true if the scheduler exists, false otherwise.
+     */
+    template <typename TBefore, typename TAfter> void RemoveDependencyBefore();
+
+    /**
+     * @brief Checks if a scheduler identified by the given type index exists in the container.
+     *
+     * This function checks if a scheduler associated with the specified type index exists in the container.
+     * It returns true if the scheduler is found, otherwise false.
+     *
+     * @tparam TAfter The type of the first scheduler.
+     * @tparam TBefore The type of the second scheduler.
+     */
+    template <typename TAfter, typename TBefore> void RemoveDependencyAfter();
+
+    /**
+     * @brief Checks if a scheduler of the specified type exists in the container.
+     *
+     * This function checks if a scheduler of the specified type TScheduler
+     * exists in the container. It returns true if the scheduler is found,
+     * otherwise false.
+     *
      * @param id The type index of the scheduler to check for.
      * @return true if the scheduler exists, false otherwise.
      */

--- a/src/engine/src/scheduler/SchedulerContainer.inl
+++ b/src/engine/src/scheduler/SchedulerContainer.inl
@@ -35,6 +35,26 @@ template <typename TAfter, typename TBefore> inline void ES::Engine::SchedulerCo
     Before<TBefore, TAfter>();
 }
 
+
+template <typename TBefore, typename TAfter> void ES::Engine::SchedulerContainer::RemoveDependencyBefore()
+{
+    _dirty = true;
+    auto it = _dependencies.find(std::type_index(typeid(TAfter)));
+    if (it != _dependencies.end())
+    {
+        it->second.erase(std::type_index(typeid(TBefore)));
+        if (it->second.empty())
+            _dependencies.erase(it);
+    } else {
+        ES::Utils::Log::Warn(fmt::format("Dependency not found: {} -> {}", typeid(TBefore).name(), typeid(TAfter).name()));
+    }
+}
+
+template <typename TAfter, typename TBefore> void ES::Engine::SchedulerContainer::RemoveDependencyAfter()
+{
+    RemoveDependencyBefore<TBefore, TAfter>();    
+}
+
 inline void ES::Engine::SchedulerContainer::RunSchedulers()
 {
     Update();

--- a/src/engine/tests/engine/Scheduler.cpp
+++ b/src/engine/tests/engine/Scheduler.cpp
@@ -3,8 +3,11 @@
 #include "Core.hpp"
 #include "Entity.hpp"
 #include "Startup.hpp"
+#include "RelativeTimeUpdate.hpp"
+#include "FixedTimeUpdate.hpp"
 
 using namespace ES::Engine;
+using namespace std::chrono_literals;
 
 struct ResourceTest {
     std::vector<int> data;
@@ -33,6 +36,7 @@ TEST(SchedulerContainer, CasualUse)
         core.RegisterResource<ResourceTest>(ResourceTest());
         core.RegisterScheduler<SchedulerTest1>();
         core.RegisterScheduler<SchedulerTest2>();
+        core.SetSchedulerAfter<SchedulerTest2, SchedulerTest1>();
         core.RunSystems();
         auto &data = core.GetResource<ResourceTest>().data;
         ASSERT_EQ(data.size(), 2);
@@ -44,6 +48,7 @@ TEST(SchedulerContainer, CasualUse)
         core.RegisterResource<ResourceTest>(ResourceTest());
         core.RegisterScheduler<SchedulerTest2>();
         core.RegisterScheduler<SchedulerTest1>();
+        core.SetSchedulerAfter<SchedulerTest1, SchedulerTest2>();
         core.RunSystems();
         auto &data = core.GetResource<ResourceTest>().data;
         ASSERT_EQ(data.size(), 2);
@@ -82,6 +87,7 @@ TEST(SchedulerContainer, DependencyBefore)
     auto &data = core.GetResource<ResourceTest>().data;
     core.RegisterScheduler<SchedulerTest2>();
     core.RegisterScheduler<SchedulerTest1>();
+    core.SetSchedulerAfter<SchedulerTest1, SchedulerTest2>();
     core.RunSystems();
     {
         ASSERT_EQ(data.size(), 2);
@@ -89,6 +95,7 @@ TEST(SchedulerContainer, DependencyBefore)
         ASSERT_EQ(data[1], 1);
     }
     data.clear();
+    core.RemoveDependencyAfter<SchedulerTest1, SchedulerTest2>();
     core.SetSchedulerBefore<SchedulerTest1, SchedulerTest2>();
     core.RunSystems();
     {
@@ -105,15 +112,29 @@ TEST(SchedulerContainer, CurrentScheduler)
     auto &data = core.GetResource<ResourceTest>().data;
     core.RegisterSystem<Scheduler::Startup>([](Core &c) { c.GetResource<ResourceTest>().data.push_back(1); });
     core.RegisterSystem<Scheduler::Update>([](Core &c) { c.GetResource<ResourceTest>().data.push_back(2); });
+    core.RegisterSystem<Scheduler::RelativeTimeUpdate>([](Core &c) { c.GetResource<ResourceTest>().data.push_back(2); });
+    core.RegisterSystem<Scheduler::FixedTimeUpdate>([](Core &c) { c.GetResource<ResourceTest>().data.push_back(2); });
     core.RegisterSystem<Scheduler::Shutdown>([](Core &c) { c.GetResource<ResourceTest>().data.push_back(3); });
 
+    core.GetScheduler<Scheduler::FixedTimeUpdate>().SetTickRate(1.0 / 5.0);
+    core.GetScheduler<Scheduler::RelativeTimeUpdate>().SetTargetTickRate(1.0 / 5.0);
+
+    std::this_thread::sleep_for(0.21s);
     core.RunSystems();
+    std::this_thread::sleep_for(0.21s);
     core.RunSystems();
 
-    ASSERT_EQ(data.size(), 5);
+    ASSERT_EQ(data.size(), 11);
     ASSERT_EQ(data[0], 1);
     ASSERT_EQ(data[1], 2);
-    ASSERT_EQ(data[2], 3);
+    ASSERT_EQ(data[2], 2);
     ASSERT_EQ(data[3], 2);
-    ASSERT_EQ(data[4], 3);
+    ASSERT_EQ(data[4], 2);
+    ASSERT_EQ(data[5], 3);
+    ASSERT_EQ(data[6], 2);
+    ASSERT_EQ(data[7], 2);
+    ASSERT_EQ(data[8], 2);
+    ASSERT_EQ(data[9], 2);
+    ASSERT_EQ(data[10], 3);
 }
+


### PR DESCRIPTION
As we hadn't defined dependencies between default schedulers, they could run in any order. So, on some machines, FixedUpdate would run before Startup.
So I added some dependencies and tests.