### PR TITLE
build: set headeronly and object for proper xmake

### DIFF
--- a/src/plugin/camera/xmake.lua
+++ b/src/plugin/camera/xmake.lua
@@ -2,7 +2,7 @@ add_rules("mode.debug", "mode.release")
 add_requires("glm")
 
 target("PluginCamera")
-    set_kind("static")
+    set_kind("headeronly")
     set_languages("cxx20")
     set_policy("build.warning", true)
 

--- a/src/plugin/colors/xmake.lua
+++ b/src/plugin/colors/xmake.lua
@@ -1,7 +1,7 @@
 add_rules("mode.debug", "mode.release")
 
 target("PluginColors")
-    set_kind("static")
+    set_kind("headeronly")
     set_languages("cxx20")
     set_policy("build.warning", true)
 

--- a/src/plugin/utils/xmake.lua
+++ b/src/plugin/utils/xmake.lua
@@ -2,7 +2,7 @@ add_rules("mode.debug", "mode.release")
 add_requires("gtest", {optional = true})
 
 target("PluginUtils")
-    set_kind("static")
+    set_kind("headeronly")
     set_languages("cxx20")
     set_policy("build.warning", true)
 

--- a/src/utils/function-container/xmake.lua
+++ b/src/utils/function-container/xmake.lua
@@ -4,7 +4,7 @@ set_languages("cxx20")
 includes("../log/xmake.lua")
 
 target("UtilsFunctionContainer")
-    set_kind("static")
+    set_kind("headeronly")
 
     add_includedirs("src/", {public = true})
 

--- a/src/utils/log/xmake.lua
+++ b/src/utils/log/xmake.lua
@@ -3,7 +3,7 @@ add_requires("spdlog", "fmt")
 set_languages("cxx20")
 
 target("UtilsLog")
-    set_kind("static")
+    set_kind("headeronly")
     add_packages("spdlog", "fmt")
 
     add_includedirs("src/", {public = true})

--- a/xmake.lua
+++ b/xmake.lua
@@ -21,7 +21,7 @@ includes("src/engine/xmake.lua")
 
 add_rules("plugin.vsxmake.autoupdate")
 target("EngineSquared")
-    set_kind("static")
+    set_kind("object")
     set_default(true)
     set_languages("cxx20")
     set_version("0.0.0")


### PR DESCRIPTION
As we are only using header file inside `Camera`, `Colors`, `Utils` plugins and `FunctionContainer`, `FunctionContainer` utils, I've defined the kind of Xmake target as header file only. And, as root Xmake only collect some other targets, I've made it a "Object".