### PR TITLE
fix: bad vehicle wheel offset and position

### DIFF
--- a/src/plugin/physics/src/utils/WheeledVehicleBuilder.hpp
+++ b/src/plugin/physics/src/utils/WheeledVehicleBuilder.hpp
@@ -235,8 +235,8 @@ template <size_t WheelCount = 4> class WheeledVehicleBuilder {
     std::array<std::unique_ptr<JPH::WheelSettingsWV>, WheelCount> wheelSettings = {nullptr};
     /// Wheels offset from the vehicle initial position.
     std::array<glm::vec3, WheelCount> wheelOffsets = {glm::vec3(0.0f, 0.0f, 0.0f)};
-    ///Wheel callback function to be called when a wheel is created.
-    /// @note This function is called after a wheel is fully initialized.
+    /// Wheel callback function to be called when a wheel is created.
+    ///  @note This function is called after a wheel is fully initialized.
     std::function<void(ES::Engine::Core &, ES::Engine::Entity &)> wheelCallbackFn = [](ES::Engine::Core &,
                                                                                        ES::Engine::Entity &) {};
     /// Vehicle callback function to be called when a vehicle is created.

--- a/src/plugin/physics/src/utils/WheeledVehicleBuilder.hpp
+++ b/src/plugin/physics/src/utils/WheeledVehicleBuilder.hpp
@@ -175,6 +175,20 @@ template <size_t WheelCount = 4> class WheeledVehicleBuilder {
         return *this;
     }
 
+    /// @brief Set a wheel offset from the vehicle initial position.
+    /// @param index The index of the wheel to set the offset for.
+    /// @param offset The offset to set.
+    /// @return A reference to the vehicle builder.
+    /// @note The index must be less than the number of wheels.
+    inline WheeledVehicleBuilder &SetWheelOffset(size_t index, const glm::vec3 &offset)
+    {
+        if (index >= WheelCount)
+            throw WheeledVehicleBuilderError("Index out of range");
+
+        wheelOffsets[index] = offset;
+        return *this;
+    }
+
     /// @brief Set a callback to be called when a vehicle is created.
     /// @param fn A callable that takes a reference to the vehicle entity and modifies it.
     /// @return A reference to the vehicle builder.
@@ -219,7 +233,9 @@ template <size_t WheelCount = 4> class WheeledVehicleBuilder {
     glm::vec3 offsetCenterOfMassShape = glm::vec3(0.0f, 0.0f, 0.0f);
     /// Wheels settings of the vehicle.
     std::array<std::unique_ptr<JPH::WheelSettingsWV>, WheelCount> wheelSettings = {nullptr};
-    /// Wheel callback function to be called when a wheel is created.
+    /// Wheels offset from the vehicle initial position.
+    std::array<glm::vec3, WheelCount> wheelOffsets = {glm::vec3(0.0f, 0.0f, 0.0f)};
+    ///Wheel callback function to be called when a wheel is created.
     /// @note This function is called after a wheel is fully initialized.
     std::function<void(ES::Engine::Core &, ES::Engine::Entity &)> wheelCallbackFn = [](ES::Engine::Core &,
                                                                                        ES::Engine::Entity &) {};

--- a/src/plugin/physics/src/utils/WheeledVehicleBuilder.inl
+++ b/src/plugin/physics/src/utils/WheeledVehicleBuilder.inl
@@ -48,9 +48,9 @@ template <size_t WheelCount> ES::Engine::Entity ES::Plugin::Physics::Utils::Whee
     {
         ES::Engine::Entity wheelEntity = core.CreateEntity();
 
-        glm::vec3 wheelPosition = glm::vec3(initialPosition.x + wheelSettings[i]->mPosition.GetX(),
-                                            initialPosition.y + wheelSettings[i]->mPosition.GetY(),
-                                            initialPosition.z + wheelSettings[i]->mPosition.GetZ());
+        glm::vec3 wheelPosition = wheelOffsets[i];
+
+        wheelSettings[i]->mPosition = JPH::Vec3(wheelPosition.x, wheelPosition.y, wheelPosition.z);
 
         wheelEntity.AddComponent<ES::Plugin::Object::Component::Transform>(core, wheelPosition);
         wheelEntity.AddComponent<ES::Plugin::Object::Component::Mesh>(core, wheelMesh.value());


### PR DESCRIPTION
Not related to any issues

Vehicle wheels were wrongly set to initial position, they should be attached by Jolt anyways
I have also added utility functions with the builder to change each wheel individually