### PR TITLE
ci: fix ci linter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ concurrency:
   cancel-in-progress: ${{ github.actor == 'github-actions[bot]' }}
 
 env:
-  MIRROR_URL: "git@github.com:EpitechPromo2026/G-EIP-700-NAN-7-1-eip-lucas.hauszler.git"
   UNWANTED_REGEX: '^(?!.*tests\/).*gc(no|da|ov)$|(.*\.(a|o|so|lib))$|(.*~)$|^(#.*#)$|^tmp\/.*|.*\/tmp\/.*'
 
 jobs:
@@ -50,11 +49,6 @@ jobs:
         run: |
           git ls-files -z "*.cpp" "*.hpp" "*.inl" | while IFS= read -rd '' f; do tail -c1 < "$f" | read -r _ || echo >> "$f"; done
           find . -iname '*.hpp' -o -iname '*.cpp' -o -iname '*.inl' | xargs clang-format -i
-
-      - name: Set up SSH
-        uses: webfactory/ssh-agent@v0.9.0
-        with:
-          ssh-private-key: ${{ secrets.GIT_SSH_PRIVATE_KEY }}
 
       - name: Set up Git
         run: |

--- a/src/engine/src/scheduler/FixedTimeUpdate.cpp
+++ b/src/engine/src/scheduler/FixedTimeUpdate.cpp
@@ -3,9 +3,7 @@
 #include "FixedTimeUpdate.hpp"
 #include "Time.hpp"
 
-void ES::Engine::Scheduler::FixedTimeUpdate::RunSystems()
-{
-    _bufferedTime += this->_core.GetResource<ES::Engine::Resource::Time>()._elapsedTime;
+void ES::Engine::Scheduler::FixedTimeUpdate::RunSystems(){_bufferedTime += this->_core.GetResource<ES::Engine::Resource::Time>()._elapsedTime;
     auto ticks = static_cast<unsigned int>(_bufferedTime / _tickRate);
     _bufferedTime -= ticks * _tickRate;
 

--- a/src/engine/src/scheduler/FixedTimeUpdate.cpp
+++ b/src/engine/src/scheduler/FixedTimeUpdate.cpp
@@ -3,7 +3,9 @@
 #include "FixedTimeUpdate.hpp"
 #include "Time.hpp"
 
-void ES::Engine::Scheduler::FixedTimeUpdate::RunSystems(){_bufferedTime += this->_core.GetResource<ES::Engine::Resource::Time>()._elapsedTime;
+void ES::Engine::Scheduler::FixedTimeUpdate::RunSystems()
+{
+    _bufferedTime += this->_core.GetResource<ES::Engine::Resource::Time>()._elapsedTime;
     auto ticks = static_cast<unsigned int>(_bufferedTime / _tickRate);
     _bufferedTime -= ticks * _tickRate;
 


### PR DESCRIPTION
Not related to any issues

Allow the linter to work again following PR #254 

Note:
- We are a public repository, so the GitHub Action bot doesn't need an SSH key or a PAT at all