### PR TITLE
fix(OpenGL): providing ability to invert Y loaded textures

### DIFF
--- a/src/plugin/opengl/src/utils/Texture.cpp
+++ b/src/plugin/opengl/src/utils/Texture.cpp
@@ -19,7 +19,8 @@ Texture::~Texture()
 
 void Texture::LoadTexture(const std::string &texturePath, bool invertY)
 {
-    stbi_set_flip_vertically_on_load(invertY);
+    if (invertY)
+        stbi_set_flip_vertically_on_load(true);
 
     uint8_t *pixels = stbi_load(texturePath.c_str(), &_width, &_height, &_channels, STBI_rgb_alpha);
 
@@ -44,7 +45,8 @@ void Texture::LoadTexture(const std::string &texturePath, bool invertY)
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 
     stbi_image_free(pixels);
-    stbi_set_flip_vertically_on_load(!invertY);
+    if (invertY)
+        stbi_set_flip_vertically_on_load(false);
     ES::Utils::Log::Info(fmt::format("Texture loaded: {}", texturePath));
 }
 

--- a/src/plugin/opengl/src/utils/Texture.cpp
+++ b/src/plugin/opengl/src/utils/Texture.cpp
@@ -6,7 +6,7 @@
 
 namespace ES::Plugin::OpenGL::Utils {
 
-Texture::Texture(const std::string &texturePath) { LoadTexture(texturePath); }
+Texture::Texture(const std::string &texturePath, bool invertY) { LoadTexture(texturePath, invertY); }
 
 Texture::~Texture()
 {
@@ -17,8 +17,11 @@ Texture::~Texture()
     _textureID = 0;
 }
 
-void Texture::LoadTexture(const std::string &texturePath)
+void Texture::LoadTexture(const std::string &texturePath, bool invertY)
 {
+    if (invertY)
+        stbi_set_flip_vertically_on_load(true);
+
     uint8_t *pixels = stbi_load(texturePath.c_str(), &_width, &_height, &_channels, STBI_rgb_alpha);
 
     if (!pixels)
@@ -42,6 +45,8 @@ void Texture::LoadTexture(const std::string &texturePath)
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 
     stbi_image_free(pixels);
+    if (invertY)
+        stbi_set_flip_vertically_on_load(false);
     ES::Utils::Log::Info(fmt::format("Texture loaded: {}", texturePath));
 }
 

--- a/src/plugin/opengl/src/utils/Texture.cpp
+++ b/src/plugin/opengl/src/utils/Texture.cpp
@@ -19,8 +19,7 @@ Texture::~Texture()
 
 void Texture::LoadTexture(const std::string &texturePath, bool invertY)
 {
-    if (invertY)
-        stbi_set_flip_vertically_on_load(true);
+    stbi_set_flip_vertically_on_load(invertY);
 
     uint8_t *pixels = stbi_load(texturePath.c_str(), &_width, &_height, &_channels, STBI_rgb_alpha);
 
@@ -45,8 +44,7 @@ void Texture::LoadTexture(const std::string &texturePath, bool invertY)
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 
     stbi_image_free(pixels);
-    if (invertY)
-        stbi_set_flip_vertically_on_load(false);
+    stbi_set_flip_vertically_on_load(!invertY);
     ES::Utils::Log::Info(fmt::format("Texture loaded: {}", texturePath));
 }
 

--- a/src/plugin/opengl/src/utils/Texture.hpp
+++ b/src/plugin/opengl/src/utils/Texture.hpp
@@ -8,7 +8,7 @@ namespace ES::Plugin::OpenGL::Utils {
 
 class Texture {
   public:
-    explicit Texture(const std::string &texturePath);
+    explicit Texture(const std::string &texturePath, bool invertY = false);
     Texture(int width, int height, int channels, GLuint textureID)
         : _width(width), _height(height), _channels(channels), _textureID(textureID)
     {
@@ -26,7 +26,7 @@ class Texture {
     [[nodiscard]] int GetHeight() const { return _height; }
 
   private:
-    void LoadTexture(const std::string &texturePath);
+    void LoadTexture(const std::string &texturePath, bool invertY);
 
   private:
     int _width = 0;


### PR DESCRIPTION
Not related to any issue.

The OpenGL plugin uses `stb` library to load the textures. The current implementation works great, however, by default, `stb_image` loads textures with the origin at the top-left corner, while OpenGL expects texture origin at the bottom-left. This causes the textures to render Y inverted.

An example can be found here:
[ES-RS](https://github.com/EngineSquared/ES-RS/pull/3)

This PR provides a fix by setting a parameter to invert them while keeping the current texture loading implementation unchanged if not given while adding a new texture to the texture manager, just like so:
`textureManager.Add(entt::hashed_string{"tex_BARRELA"}, "asset/textures/BARRELA.png", true);`