### PR TITLE
feat(OpenGL): handling camera rotation from a source target

### DIFF
--- a/src/plugin/opengl/src/utils/Viewer.cpp
+++ b/src/plugin/opengl/src/utils/Viewer.cpp
@@ -169,6 +169,27 @@ void Viewer::setZoomFraction(float zoomFraction) { m_zoomFraction = zoomFraction
 
 void Viewer::setRotateSpeed(float rotateSpeed) { m_rotateSpeed = rotateSpeed; }
 
+glm::quat Viewer::getRotation() const
+{
+    glm::vec3 viewDir = glm::normalize(m_viewCenter - m_viewPoint);
+    glm::vec3 rightDir = glm::normalize(glm::cross(viewDir, m_upVector));
+    glm::vec3 correctedUp = glm::normalize(glm::cross(rightDir, viewDir));
+
+    glm::mat3 rotationMatrix(
+        rightDir,
+        correctedUp,
+        -viewDir
+    );
+
+    return glm::quat_cast(rotationMatrix);
+}
+
+void Viewer::rotate(const glm::quat &srcRotation, const glm::vec3 &srcOffset)
+{
+    glm::vec3 rotatedOffset = srcRotation * srcOffset;
+    m_viewPoint = m_viewCenter + rotatedOffset;
+}
+
 void Viewer::getFrustrumInfo()
 {
     // Get the viewing direction

--- a/src/plugin/opengl/src/utils/Viewer.cpp
+++ b/src/plugin/opengl/src/utils/Viewer.cpp
@@ -175,11 +175,7 @@ glm::quat Viewer::getRotation() const
     glm::vec3 rightDir = glm::normalize(glm::cross(viewDir, m_upVector));
     glm::vec3 correctedUp = glm::normalize(glm::cross(rightDir, viewDir));
 
-    glm::mat3 rotationMatrix(
-        rightDir,
-        correctedUp,
-        -viewDir
-    );
+    glm::mat3 rotationMatrix(rightDir, correctedUp, -viewDir);
 
     return glm::quat_cast(rotationMatrix);
 }

--- a/src/plugin/opengl/src/utils/Viewer.hpp
+++ b/src/plugin/opengl/src/utils/Viewer.hpp
@@ -46,6 +46,9 @@ class Viewer {
     /** The worldspace direction (i.e., normalized vector) of the vertical image axis	*/
     glm::vec3 getImagePlaneVertDir() const;
 
+    /** The rotation quaternion vector */
+    glm::quat getRotation() const;
+
     /**
      * Translate
      *
@@ -95,6 +98,19 @@ class Viewer {
      * is controlled by m_rotateSpeed.
      */
     void rotate(float changeHoriz, float changeVert);
+
+    /**
+     * Rotate
+     *
+     * These methods alter the view based on mouse movement.  The arguments
+     * srcRotation and srcOffset specify, respectively, the object the camera should set its rotation
+     * and the start offset, in case the target object has been rotated.
+     *
+     * rotate: Rotate based on a target quaternion; the first argument is for
+     * rotation about the target quaternion and the second is for
+     * the start offset of the rotation.
+     */
+    void rotate(const glm::quat &srcRotation, const glm::vec3 &srcOffset);
 
     /**
      * Center at


### PR DESCRIPTION
Not related to any issue.

The OpenGL Viewer class doesn't provide any getter for the camera rotation, nor a simple way to rotate it based on a source rotation. I added both functions to easily set it from a target.

A usage example can be found here:
- [ES-RS](https://github.com/EngineSquared/ES-RS/pull/4)