### PR TITLE
fix(UI): allowing assignment of multiple event listeners per document

### DIFF
--- a/src/plugin/ui/src/resource/UIResource.hpp
+++ b/src/plugin/ui/src/resource/UIResource.hpp
@@ -8,11 +8,23 @@
 namespace ES::Plugin::UI::Resource {
 class UIResource {
   private:
+    struct TransparentHash {
+        using is_transparent = void;
+
+        std::size_t operator()(std::string_view key) const noexcept { return std::hash<std::string_view>{}(key); }
+    };
+
+    struct TransparentEqual {
+        using is_transparent = void;
+
+        bool operator()(std::string_view lhs, std::string_view rhs) const noexcept { return lhs == rhs; }
+    };
+
     Rml::Context *_context;
     Rml::ElementDocument *_document;
     std::unique_ptr<ES::Plugin::UI::Utils::SystemInterface> _systemInterface;
     std::unique_ptr<ES::Plugin::UI::Utils::RenderInterface> _renderInterface;
-    std::unordered_map<std::string, std::unique_ptr<ES::Plugin::UI::Utils::EventListener>> _events;
+    std::unordered_map<std::string, std::unique_ptr<ES::Plugin::UI::Utils::EventListener>, TransparentHash, TransparentEqual> _events;
 
   public:
     /**

--- a/src/plugin/ui/src/resource/UIResource.hpp
+++ b/src/plugin/ui/src/resource/UIResource.hpp
@@ -12,7 +12,7 @@ class UIResource {
     Rml::ElementDocument *_document;
     std::unique_ptr<ES::Plugin::UI::Utils::SystemInterface> _systemInterface;
     std::unique_ptr<ES::Plugin::UI::Utils::RenderInterface> _renderInterface;
-    std::unique_ptr<ES::Plugin::UI::Utils::EventListener> _event;
+    std::unordered_map<std::string, std::unique_ptr<ES::Plugin::UI::Utils::EventListener>> _events;
 
   public:
     /**
@@ -55,7 +55,7 @@ class UIResource {
      *
      * @return void
      */
-    void BindEventCallback();
+    void BindEventCallback(ES::Engine::Core &core);
 
     /**
      * @brief Update the mouse position event
@@ -144,12 +144,24 @@ class UIResource {
     /**
      * @brief Attach the event listener handlers
      *
-     * @param childId The node id to modify
+     * @param elementId The element to attach the listener on
+     * @param eventType The type of event to apply: [click, dblclick, mouseover, mouseout, mousemove, mouseup, mousedown, mousescroll]
+     * @param callback The callback function called when the event is triggered
      *
      * @return void
      */
     void AttachEventHandlers(const std::string &elementId, const std::string &eventType,
                              ES::Plugin::UI::Utils::EventListener::EventCallback callback);
+
+    /**
+     * @brief Detach the event listener handlers
+     *
+     * @param elementId The target element to remove the event
+     * @param eventType The type of event to remove: [click, dblclick, mouseover, mouseout, mousemove, mouseup, mousedown, mousescroll]
+     *
+     * @return void
+     */
+    void DetachEventHandler(const std::string &elementId, const std::string &eventType);
 
     /**
      * @brief Check if the UI plugin is ready

--- a/src/plugin/ui/src/resource/UIResource.hpp
+++ b/src/plugin/ui/src/resource/UIResource.hpp
@@ -24,7 +24,9 @@ class UIResource {
     Rml::ElementDocument *_document;
     std::unique_ptr<ES::Plugin::UI::Utils::SystemInterface> _systemInterface;
     std::unique_ptr<ES::Plugin::UI::Utils::RenderInterface> _renderInterface;
-    std::unordered_map<std::string, std::unique_ptr<ES::Plugin::UI::Utils::EventListener>, TransparentHash, TransparentEqual> _events;
+    std::unordered_map<std::string, std::unique_ptr<ES::Plugin::UI::Utils::EventListener>, TransparentHash,
+                       TransparentEqual>
+        _events;
 
   public:
     /**

--- a/src/plugin/ui/src/system/InitUI.cpp
+++ b/src/plugin/ui/src/system/InitUI.cpp
@@ -8,7 +8,7 @@ void ES::Plugin::UI::System::Init(ES::Engine::Core &core)
 
 void ES::Plugin::UI::System::BindEventCallback(ES::Engine::Core &core)
 {
-    core.GetResource<ES::Plugin::UI::Resource::UIResource>().BindEventCallback();
+    core.GetResource<ES::Plugin::UI::Resource::UIResource>().BindEventCallback(core);
 }
 
 void ES::Plugin::UI::System::Destroy(ES::Engine::Core &core)

--- a/src/plugin/ui/src/utils/EventListener.cpp
+++ b/src/plugin/ui/src/utils/EventListener.cpp
@@ -1,8 +1,8 @@
 #include "EventListener.hpp"
 
-void ES::Plugin::UI::Utils::EventListener::SetCallback()
+void ES::Plugin::UI::Utils::EventListener::SetCallback(ES::Engine::Core &core)
 {
-    auto &inputManager = _core.GetResource<ES::Plugin::Input::Resource::InputManager>();
+    auto &inputManager = core.GetResource<ES::Plugin::Input::Resource::InputManager>();
     inputManager.RegisterMouseButtonCallback(
         [this](const ES::Engine::Core &, int key, int action, int mods) { ProcessMouseButton(key, action, mods); });
 }

--- a/src/plugin/ui/src/utils/EventListener.hpp
+++ b/src/plugin/ui/src/utils/EventListener.hpp
@@ -17,7 +17,6 @@ class EventListener : public Rml::EventListener {
     using EventCallback = std::function<void(const std::string &event_name, const std::string &element_id)>;
 
   private:
-    ES::Engine::Core &_core;
     Rml::Context *_context;
     EventCallback _event_callback;
 
@@ -39,9 +38,9 @@ class EventListener : public Rml::EventListener {
 
   public:
     EventListener() = delete;
-    EventListener(ES::Engine::Core &core, Rml::Context &context) : _core(core), _context(&context) {}
+    EventListener(Rml::Context &context) : _context(&context) {}
 
-    void SetCallback();
+    void SetCallback(ES::Engine::Core &core);
     void ProcessMouseButton(int button, int action, int mods);
     void AttachEvents(const std::string &eventType, Rml::Element &toElement);
     void SetEventCallback(EventCallback callback);

--- a/src/plugin/ui/src/utils/EventListener.hpp
+++ b/src/plugin/ui/src/utils/EventListener.hpp
@@ -38,7 +38,7 @@ class EventListener : public Rml::EventListener {
 
   public:
     EventListener() = delete;
-    EventListener(Rml::Context &context) : _context(&context) {}
+    explicit EventListener(Rml::Context &context) : _context(&context) {}
 
     void SetCallback(ES::Engine::Core &core);
     void ProcessMouseButton(int button, int action, int mods);


### PR DESCRIPTION
Not related to any issue:

The current implementation of the Event Handlers of Rmlui doesn't allow the usage of multiple callbacks per document. This PR provides a fix for it, so multiple callbacks can be assigned to different UI elements.