### PR TITLE
refactor: remove some warnings

### DIFF
--- a/src/engine/src/plugin/IPlugin.hpp
+++ b/src/engine/src/plugin/IPlugin.hpp
@@ -3,6 +3,7 @@
 namespace ES::Engine {
 class IPlugin {
   public:
+    virtual ~IPlugin() = default;
     virtual void Bind(void) = 0;
 };
 } // namespace ES::Engine

--- a/src/plugin/opengl/src/utils/Loader.hpp
+++ b/src/plugin/opengl/src/utils/Loader.hpp
@@ -317,8 +317,7 @@ class ShaderProgram {
         }
         else
         {
-            std::string msg = "Shader program " + programId;
-            msg += " not initialised - aborting.";
+            std::string msg = fmt::format("Shader program {} not initialised - aborting.", programId);
             throw OpenGLError(msg);
         }
     }

--- a/src/plugin/physics/src/utils/ContactListenerImpl.hpp
+++ b/src/plugin/physics/src/utils/ContactListenerImpl.hpp
@@ -30,7 +30,7 @@ class ContactListenerImpl final : public JPH::ContactListener {
     JPH::ValidateResult OnContactValidate([[maybe_unused]] const JPH::Body &inBody1,
                                           [[maybe_unused]] const JPH::Body &inBody2,
                                           [[maybe_unused]] JPH::RVec3Arg inBaseOffset,
-                                          [[maybe_unused]] const JPH::CollideShapeResult &inCollisionResult)
+                                          [[maybe_unused]] const JPH::CollideShapeResult &inCollisionResult) override
     {
         return JPH::ValidateResult::AcceptAllContactsForThisBodyPair;
     }


### PR DESCRIPTION
Related to no issue.

When compiling on MacOS, I have some warnings which I fixed in this PR. I know that MacOS isn't officially in our supported platforms but it's also generally more clean.