### PR TITLE
feat(object): add Shape struct and OBJLoader support for shapes

### DIFF
--- a/src/plugin/object/src/resource/OBJLoader.cpp
+++ b/src/plugin/object/src/resource/OBJLoader.cpp
@@ -9,10 +9,8 @@ namespace ES::Plugin::Object::Resource {
 
 namespace {
 
-bool validateAndLoadObj(const std::string& path,
-                        tinyobj::attrib_t& attrib,
-                        std::vector<tinyobj::shape_t>& shapes,
-                        std::vector<tinyobj::material_t>& materials)
+bool validateAndLoadObj(const std::string &path, tinyobj::attrib_t &attrib, std::vector<tinyobj::shape_t> &shapes,
+                        std::vector<tinyobj::material_t> &materials)
 {
     std::string warn, err;
 
@@ -34,43 +32,34 @@ bool validateAndLoadObj(const std::string& path,
     return true;
 }
 
-inline Component::Vertex buildVertex(const tinyobj::attrib_t& attrib, const tinyobj::index_t& idx)
+inline Component::Vertex buildVertex(const tinyobj::attrib_t &attrib, const tinyobj::index_t &idx)
 {
     Component::Vertex v{};
 
-    v.pos = {
-        attrib.vertices[3 * idx.vertex_index + 0],
-        attrib.vertices[3 * idx.vertex_index + 1],
-        attrib.vertices[3 * idx.vertex_index + 2]};
+    v.pos = {attrib.vertices[3 * idx.vertex_index + 0], attrib.vertices[3 * idx.vertex_index + 1],
+             attrib.vertices[3 * idx.vertex_index + 2]};
 
     if (!attrib.normals.empty() && idx.normal_index >= 0)
     {
-        v.normal = {
-            attrib.normals[3 * idx.normal_index + 0],
-            attrib.normals[3 * idx.normal_index + 1],
-            attrib.normals[3 * idx.normal_index + 2]};
+        v.normal = {attrib.normals[3 * idx.normal_index + 0], attrib.normals[3 * idx.normal_index + 1],
+                    attrib.normals[3 * idx.normal_index + 2]};
     }
 
     // UV (si disponible)
     if (!attrib.texcoords.empty() && idx.texcoord_index >= 0)
     {
-        v.texCoord = {
-            attrib.texcoords[2 * idx.texcoord_index + 0],
-            VK_REVERSE_Y_TEX attrib.texcoords[2 * idx.texcoord_index + 1]};
+        v.texCoord = {attrib.texcoords[2 * idx.texcoord_index + 0],
+                      VK_REVERSE_Y_TEX attrib.texcoords[2 * idx.texcoord_index + 1]};
     }
 
     return v;
 }
 
-void appendShapeFlat(const tinyobj::attrib_t& attrib,
-                     const tinyobj::shape_t& inShape,
-                     std::unordered_map<Component::Vertex, uint32_t>& uniqueVertices,
-                     std::vector<glm::vec3>& vertices,
-                     std::vector<glm::vec3>& normals,
-                     std::vector<glm::vec2>& texCoords,
-                     std::vector<uint32_t>& indices)
+void appendShapeFlat(const tinyobj::attrib_t &attrib, const tinyobj::shape_t &inShape,
+                     std::unordered_map<Component::Vertex, uint32_t> &uniqueVertices, std::vector<glm::vec3> &vertices,
+                     std::vector<glm::vec3> &normals, std::vector<glm::vec2> &texCoords, std::vector<uint32_t> &indices)
 {
-    for (const auto& idx : inShape.mesh.indices)
+    for (const auto &idx : inShape.mesh.indices)
     {
         Component::Vertex v = buildVertex(attrib, idx);
 
@@ -91,14 +80,12 @@ void appendShapeFlat(const tinyobj::attrib_t& attrib,
     }
 }
 
-void appendShapeSeparated(const tinyobj::attrib_t& attrib,
-                          const tinyobj::shape_t& inShape,
-                          Shape& outShape)
+void appendShapeSeparated(const tinyobj::attrib_t &attrib, const tinyobj::shape_t &inShape, Shape &outShape)
 {
     std::unordered_map<Component::Vertex, uint32_t> uniqueVertices;
     uniqueVertices.reserve(inShape.mesh.indices.size());
 
-    for (const auto& idx : inShape.mesh.indices)
+    for (const auto &idx : inShape.mesh.indices)
     {
         Component::Vertex v = buildVertex(attrib, idx);
 
@@ -121,11 +108,8 @@ void appendShapeSeparated(const tinyobj::attrib_t& attrib,
 
 } // anonymous namespace
 
-bool OBJLoader::loadModel(const std::string &path,
-                          std::vector<glm::vec3> &vertices,
-                          std::vector<glm::vec3> &normals,
-                          std::vector<glm::vec2> &texCoords,
-                          std::vector<uint32_t> &indices)
+bool OBJLoader::loadModel(const std::string &path, std::vector<glm::vec3> &vertices, std::vector<glm::vec3> &normals,
+                          std::vector<glm::vec2> &texCoords, std::vector<uint32_t> &indices)
 {
     tinyobj::attrib_t attrib;
     std::vector<tinyobj::shape_t> shapes;
@@ -134,7 +118,10 @@ bool OBJLoader::loadModel(const std::string &path,
     if (!validateAndLoadObj(path, attrib, shapes, materials))
         return false;
 
-    vertices.clear(); normals.clear(); texCoords.clear(); indices.clear();
+    vertices.clear();
+    normals.clear();
+    texCoords.clear();
+    indices.clear();
 
     vertices.reserve(attrib.vertices.size() / 3);
     normals.reserve(attrib.normals.size() / 3);
@@ -144,7 +131,7 @@ bool OBJLoader::loadModel(const std::string &path,
     std::unordered_map<Component::Vertex, uint32_t> uniqueVertices;
     uniqueVertices.reserve(vertices.capacity());
 
-    for (const auto& s : shapes)
+    for (const auto &s : shapes)
         appendShapeFlat(attrib, s, uniqueVertices, vertices, normals, texCoords, indices);
 
     return true;
@@ -162,7 +149,7 @@ bool OBJLoader::loadModel(const std::string &path, std::vector<Shape> &shape)
     shape.clear();
     shape.reserve(shapesIn.size());
 
-    for (const auto& inShape : shapesIn)
+    for (const auto &inShape : shapesIn)
     {
         Shape out{};
         out.vertices.reserve(inShape.mesh.indices.size()); // estimation

--- a/src/plugin/object/src/resource/OBJLoader.cpp
+++ b/src/plugin/object/src/resource/OBJLoader.cpp
@@ -110,7 +110,7 @@ void appendShapeSeparated(const tinyobj::attrib_t &attrib, const tinyobj::shape_
     }
 }
 
-}
+} // namespace
 
 bool OBJLoader::loadModel(const std::string &path, std::vector<glm::vec3> &vertices, std::vector<glm::vec3> &normals,
                           std::vector<glm::vec2> &texCoords, std::vector<uint32_t> &indices)
@@ -164,4 +164,4 @@ bool OBJLoader::loadModel(const std::string &path, std::vector<Shape> &shape)
     return true;
 }
 
-}
+} // namespace ES::Plugin::Object::Resource

--- a/src/plugin/object/src/resource/OBJLoader.cpp
+++ b/src/plugin/object/src/resource/OBJLoader.cpp
@@ -77,4 +77,79 @@ bool OBJLoader::loadModel(const std::string &path, std::vector<glm::vec3> &verti
     return true;
 }
 
+bool OBJLoader::loadModel(const std::string &path, std::vector<Shape> &shape)
+{
+    tinyobj::attrib_t attrib;
+    std::vector<tinyobj::shape_t> shapes;
+    std::vector<tinyobj::material_t> materials;
+    std::string warn;
+    std::string err;
+
+    if (path.empty())
+    {
+        ES::Utils::Log::Warn("The path is empty.");
+        return false;
+    }
+
+    else if (path.ends_with(".obj") == false)
+    {
+        ES::Utils::Log::Warn("The file is not a .obj file.");
+        return false;
+    }
+
+    else if (!tinyobj::LoadObj(&attrib, &shapes, &materials, &warn, &err, path.c_str()))
+    {
+        ES::Utils::Log::Warn(warn + err);
+        return false;
+    }
+
+    shape.clear();
+    shape.reserve(shapes.size());
+
+    for (const auto &inShape : shapes)
+    {
+        Shape out{};
+        std::unordered_map<Component::Vertex, uint32_t> uniqueVertices{};
+
+        for (const auto &index : inShape.mesh.indices)
+        {
+            Component::Vertex vertex{};
+
+            vertex.pos = {
+                attrib.vertices[3 * index.vertex_index + 0],
+                attrib.vertices[3 * index.vertex_index + 1],
+                attrib.vertices[3 * index.vertex_index + 2]};
+
+            if (!attrib.normals.empty() && index.normal_index >= 0)
+            {
+                vertex.normal = {
+                    attrib.normals[3 * index.normal_index + 0],
+                    attrib.normals[3 * index.normal_index + 1],
+                    attrib.normals[3 * index.normal_index + 2]};
+            }
+
+            if (!attrib.texcoords.empty() && index.texcoord_index >= 0)
+            {
+                vertex.texCoord = {
+                    attrib.texcoords[2 * index.texcoord_index + 0],
+                    VK_REVERSE_Y_TEX attrib.texcoords[2 * index.texcoord_index + 1]};
+            }
+
+            if (uniqueVertices.count(vertex) == 0)
+            {
+                uniqueVertices[vertex] = static_cast<uint32_t>(out.vertices.size());
+                out.vertices.emplace_back(vertex.pos);
+                out.normals.emplace_back(vertex.normal);
+                out.texCoords.emplace_back(vertex.texCoord);
+            }
+
+            out.indices.emplace_back(uniqueVertices[vertex]);
+        }
+
+        shape.emplace_back(std::move(out));
+    }
+
+    return true;
+}
+
 } // namespace ES::Plugin::Object::Resource

--- a/src/plugin/object/src/resource/OBJLoader.cpp
+++ b/src/plugin/object/src/resource/OBJLoader.cpp
@@ -115,24 +115,19 @@ bool OBJLoader::loadModel(const std::string &path, std::vector<Shape> &shape)
         {
             Component::Vertex vertex{};
 
-            vertex.pos = {
-                attrib.vertices[3 * index.vertex_index + 0],
-                attrib.vertices[3 * index.vertex_index + 1],
-                attrib.vertices[3 * index.vertex_index + 2]};
+            vertex.pos = {attrib.vertices[3 * index.vertex_index + 0], attrib.vertices[3 * index.vertex_index + 1],
+                          attrib.vertices[3 * index.vertex_index + 2]};
 
             if (!attrib.normals.empty() && index.normal_index >= 0)
             {
-                vertex.normal = {
-                    attrib.normals[3 * index.normal_index + 0],
-                    attrib.normals[3 * index.normal_index + 1],
-                    attrib.normals[3 * index.normal_index + 2]};
+                vertex.normal = {attrib.normals[3 * index.normal_index + 0], attrib.normals[3 * index.normal_index + 1],
+                                 attrib.normals[3 * index.normal_index + 2]};
             }
 
             if (!attrib.texcoords.empty() && index.texcoord_index >= 0)
             {
-                vertex.texCoord = {
-                    attrib.texcoords[2 * index.texcoord_index + 0],
-                    VK_REVERSE_Y_TEX attrib.texcoords[2 * index.texcoord_index + 1]};
+                vertex.texCoord = {attrib.texcoords[2 * index.texcoord_index + 0],
+                                   VK_REVERSE_Y_TEX attrib.texcoords[2 * index.texcoord_index + 1]};
             }
 
             if (uniqueVertices.count(vertex) == 0)

--- a/src/plugin/object/src/resource/OBJLoader.cpp
+++ b/src/plugin/object/src/resource/OBJLoader.cpp
@@ -7,72 +7,145 @@
 
 namespace ES::Plugin::Object::Resource {
 
-bool OBJLoader::loadModel(const std::string &path, std::vector<glm::vec3> &vertices, std::vector<glm::vec3> &normals,
-                          std::vector<glm::vec2> &texCoords, std::vector<uint32_t> &indices)
+namespace {
+
+bool validateAndLoadObj(const std::string& path,
+                        tinyobj::attrib_t& attrib,
+                        std::vector<tinyobj::shape_t>& shapes,
+                        std::vector<tinyobj::material_t>& materials)
 {
-    tinyobj::attrib_t attrib;
-    std::vector<tinyobj::shape_t> shapes;
-    std::vector<tinyobj::material_t> materials;
-    std::string warn;
-    std::string err;
+    std::string warn, err;
 
     if (path.empty())
     {
         ES::Utils::Log::Warn("The path is empty.");
         return false;
     }
-
-    else if (path.ends_with(".obj") == false)
+    if (!path.ends_with(".obj"))
     {
         ES::Utils::Log::Warn("The file is not a .obj file.");
         return false;
     }
-
-    else if (!tinyobj::LoadObj(&attrib, &shapes, &materials, &warn, &err, path.c_str()))
+    if (!tinyobj::LoadObj(&attrib, &shapes, &materials, &warn, &err, path.c_str()))
     {
         ES::Utils::Log::Warn(warn + err);
         return false;
     }
+    return true;
+}
+
+inline Component::Vertex buildVertex(const tinyobj::attrib_t& attrib, const tinyobj::index_t& idx)
+{
+    Component::Vertex v{};
+
+    v.pos = {
+        attrib.vertices[3 * idx.vertex_index + 0],
+        attrib.vertices[3 * idx.vertex_index + 1],
+        attrib.vertices[3 * idx.vertex_index + 2]};
+
+    if (!attrib.normals.empty() && idx.normal_index >= 0)
+    {
+        v.normal = {
+            attrib.normals[3 * idx.normal_index + 0],
+            attrib.normals[3 * idx.normal_index + 1],
+            attrib.normals[3 * idx.normal_index + 2]};
+    }
+
+    // UV (si disponible)
+    if (!attrib.texcoords.empty() && idx.texcoord_index >= 0)
+    {
+        v.texCoord = {
+            attrib.texcoords[2 * idx.texcoord_index + 0],
+            VK_REVERSE_Y_TEX attrib.texcoords[2 * idx.texcoord_index + 1]};
+    }
+
+    return v;
+}
+
+void appendShapeFlat(const tinyobj::attrib_t& attrib,
+                     const tinyobj::shape_t& inShape,
+                     std::unordered_map<Component::Vertex, uint32_t>& uniqueVertices,
+                     std::vector<glm::vec3>& vertices,
+                     std::vector<glm::vec3>& normals,
+                     std::vector<glm::vec2>& texCoords,
+                     std::vector<uint32_t>& indices)
+{
+    for (const auto& idx : inShape.mesh.indices)
+    {
+        Component::Vertex v = buildVertex(attrib, idx);
+
+        auto it = uniqueVertices.find(v);
+        if (it == uniqueVertices.end())
+        {
+            uint32_t newIndex = static_cast<uint32_t>(vertices.size());
+            uniqueVertices.emplace(v, newIndex);
+            vertices.emplace_back(v.pos);
+            normals.emplace_back(v.normal);
+            texCoords.emplace_back(v.texCoord);
+            indices.emplace_back(newIndex);
+        }
+        else
+        {
+            indices.emplace_back(it->second);
+        }
+    }
+}
+
+void appendShapeSeparated(const tinyobj::attrib_t& attrib,
+                          const tinyobj::shape_t& inShape,
+                          Shape& outShape)
+{
+    std::unordered_map<Component::Vertex, uint32_t> uniqueVertices;
+    uniqueVertices.reserve(inShape.mesh.indices.size());
+
+    for (const auto& idx : inShape.mesh.indices)
+    {
+        Component::Vertex v = buildVertex(attrib, idx);
+
+        auto it = uniqueVertices.find(v);
+        if (it == uniqueVertices.end())
+        {
+            uint32_t newIndex = static_cast<uint32_t>(outShape.vertices.size());
+            uniqueVertices.emplace(v, newIndex);
+            outShape.vertices.emplace_back(v.pos);
+            outShape.normals.emplace_back(v.normal);
+            outShape.texCoords.emplace_back(v.texCoord);
+            outShape.indices.emplace_back(newIndex);
+        }
+        else
+        {
+            outShape.indices.emplace_back(it->second);
+        }
+    }
+}
+
+} // anonymous namespace
+
+bool OBJLoader::loadModel(const std::string &path,
+                          std::vector<glm::vec3> &vertices,
+                          std::vector<glm::vec3> &normals,
+                          std::vector<glm::vec2> &texCoords,
+                          std::vector<uint32_t> &indices)
+{
+    tinyobj::attrib_t attrib;
+    std::vector<tinyobj::shape_t> shapes;
+    std::vector<tinyobj::material_t> materials;
+
+    if (!validateAndLoadObj(path, attrib, shapes, materials))
+        return false;
+
+    vertices.clear(); normals.clear(); texCoords.clear(); indices.clear();
 
     vertices.reserve(attrib.vertices.size() / 3);
     normals.reserve(attrib.normals.size() / 3);
     texCoords.reserve(attrib.texcoords.size() / 2);
-    indices.reserve(attrib.vertices.size());
+    indices.reserve(shapes.empty() ? 0 : shapes.front().mesh.indices.size() * shapes.size());
 
-    std::unordered_map<Component::Vertex, uint32_t> uniqueVertices{};
+    std::unordered_map<Component::Vertex, uint32_t> uniqueVertices;
+    uniqueVertices.reserve(vertices.capacity());
 
-    for (const auto &shape : shapes)
-    {
-        for (const auto &index : shape.mesh.indices)
-        {
-            Component::Vertex vertex{};
-
-            vertex.pos = {attrib.vertices[3 * index.vertex_index + 0], attrib.vertices[3 * index.vertex_index + 1],
-                          attrib.vertices[3 * index.vertex_index + 2]};
-
-            if (attrib.normals.size() > 0)
-            {
-                vertex.normal = {attrib.normals[3 * index.normal_index + 0], attrib.normals[3 * index.normal_index + 1],
-                                 attrib.normals[3 * index.normal_index + 2]};
-            }
-
-            if (attrib.texcoords.size() > 0)
-            {
-                vertex.texCoord = {attrib.texcoords[2 * index.texcoord_index + 0],
-                                   VK_REVERSE_Y_TEX attrib.texcoords[2 * index.texcoord_index + 1]};
-            }
-
-            if (uniqueVertices.count(vertex) == 0)
-            {
-                uniqueVertices[vertex] = static_cast<uint32_t>(vertices.size());
-                vertices.emplace_back(vertex.pos);
-                normals.emplace_back(vertex.normal);
-                texCoords.emplace_back(vertex.texCoord);
-            }
-
-            indices.emplace_back(uniqueVertices[vertex]);
-        }
-    }
+    for (const auto& s : shapes)
+        appendShapeFlat(attrib, s, uniqueVertices, vertices, normals, texCoords, indices);
 
     return true;
 }
@@ -80,67 +153,20 @@ bool OBJLoader::loadModel(const std::string &path, std::vector<glm::vec3> &verti
 bool OBJLoader::loadModel(const std::string &path, std::vector<Shape> &shape)
 {
     tinyobj::attrib_t attrib;
-    std::vector<tinyobj::shape_t> shapes;
+    std::vector<tinyobj::shape_t> shapesIn;
     std::vector<tinyobj::material_t> materials;
-    std::string warn;
-    std::string err;
 
-    if (path.empty())
-    {
-        ES::Utils::Log::Warn("The path is empty.");
+    if (!validateAndLoadObj(path, attrib, shapesIn, materials))
         return false;
-    }
-
-    else if (path.ends_with(".obj") == false)
-    {
-        ES::Utils::Log::Warn("The file is not a .obj file.");
-        return false;
-    }
-
-    else if (!tinyobj::LoadObj(&attrib, &shapes, &materials, &warn, &err, path.c_str()))
-    {
-        ES::Utils::Log::Warn(warn + err);
-        return false;
-    }
 
     shape.clear();
-    shape.reserve(shapes.size());
+    shape.reserve(shapesIn.size());
 
-    for (const auto &inShape : shapes)
+    for (const auto& inShape : shapesIn)
     {
         Shape out{};
-        std::unordered_map<Component::Vertex, uint32_t> uniqueVertices{};
-
-        for (const auto &index : inShape.mesh.indices)
-        {
-            Component::Vertex vertex{};
-
-            vertex.pos = {attrib.vertices[3 * index.vertex_index + 0], attrib.vertices[3 * index.vertex_index + 1],
-                          attrib.vertices[3 * index.vertex_index + 2]};
-
-            if (!attrib.normals.empty() && index.normal_index >= 0)
-            {
-                vertex.normal = {attrib.normals[3 * index.normal_index + 0], attrib.normals[3 * index.normal_index + 1],
-                                 attrib.normals[3 * index.normal_index + 2]};
-            }
-
-            if (!attrib.texcoords.empty() && index.texcoord_index >= 0)
-            {
-                vertex.texCoord = {attrib.texcoords[2 * index.texcoord_index + 0],
-                                   VK_REVERSE_Y_TEX attrib.texcoords[2 * index.texcoord_index + 1]};
-            }
-
-            if (uniqueVertices.count(vertex) == 0)
-            {
-                uniqueVertices[vertex] = static_cast<uint32_t>(out.vertices.size());
-                out.vertices.emplace_back(vertex.pos);
-                out.normals.emplace_back(vertex.normal);
-                out.texCoords.emplace_back(vertex.texCoord);
-            }
-
-            out.indices.emplace_back(uniqueVertices[vertex]);
-        }
-
+        out.vertices.reserve(inShape.mesh.indices.size()); // estimation
+        appendShapeSeparated(attrib, inShape, out);
         shape.emplace_back(std::move(out));
     }
 

--- a/src/plugin/object/src/resource/OBJLoader.cpp
+++ b/src/plugin/object/src/resource/OBJLoader.cpp
@@ -12,23 +12,27 @@ namespace {
 bool validateAndLoadObj(const std::string &path, tinyobj::attrib_t &attrib, std::vector<tinyobj::shape_t> &shapes,
                         std::vector<tinyobj::material_t> &materials)
 {
-    std::string warn, err;
+    std::string warn;
+    std::string err;
 
     if (path.empty())
     {
         ES::Utils::Log::Warn("The path is empty.");
         return false;
     }
+
     if (!path.ends_with(".obj"))
     {
         ES::Utils::Log::Warn("The file is not a .obj file.");
         return false;
     }
+
     if (!tinyobj::LoadObj(&attrib, &shapes, &materials, &warn, &err, path.c_str()))
     {
         ES::Utils::Log::Warn(warn + err);
         return false;
     }
+
     return true;
 }
 
@@ -45,7 +49,6 @@ inline Component::Vertex buildVertex(const tinyobj::attrib_t &attrib, const tiny
                     attrib.normals[3 * idx.normal_index + 2]};
     }
 
-    // UV (si disponible)
     if (!attrib.texcoords.empty() && idx.texcoord_index >= 0)
     {
         v.texCoord = {attrib.texcoords[2 * idx.texcoord_index + 0],
@@ -83,6 +86,7 @@ void appendShapeFlat(const tinyobj::attrib_t &attrib, const tinyobj::shape_t &in
 void appendShapeSeparated(const tinyobj::attrib_t &attrib, const tinyobj::shape_t &inShape, Shape &outShape)
 {
     std::unordered_map<Component::Vertex, uint32_t> uniqueVertices;
+
     uniqueVertices.reserve(inShape.mesh.indices.size());
 
     for (const auto &idx : inShape.mesh.indices)
@@ -106,7 +110,7 @@ void appendShapeSeparated(const tinyobj::attrib_t &attrib, const tinyobj::shape_
     }
 }
 
-} // anonymous namespace
+}
 
 bool OBJLoader::loadModel(const std::string &path, std::vector<glm::vec3> &vertices, std::vector<glm::vec3> &normals,
                           std::vector<glm::vec2> &texCoords, std::vector<uint32_t> &indices)
@@ -152,7 +156,7 @@ bool OBJLoader::loadModel(const std::string &path, std::vector<Shape> &shape)
     for (const auto &inShape : shapesIn)
     {
         Shape out{};
-        out.vertices.reserve(inShape.mesh.indices.size()); // estimation
+        out.vertices.reserve(inShape.mesh.indices.size());
         appendShapeSeparated(attrib, inShape, out);
         shape.emplace_back(std::move(out));
     }
@@ -160,4 +164,4 @@ bool OBJLoader::loadModel(const std::string &path, std::vector<Shape> &shape)
     return true;
 }
 
-} // namespace ES::Plugin::Object::Resource
+}

--- a/src/plugin/object/src/resource/OBJLoader.hpp
+++ b/src/plugin/object/src/resource/OBJLoader.hpp
@@ -28,6 +28,7 @@
 #include <vector>
 
 #include "component/Vertex.hpp"
+#include "utils/Shape.hpp"
 
 #if defined(VULKAN)
 #    define VK_REVERSE_Y_TEX 1.0f - // NOSONAR
@@ -56,6 +57,8 @@ class OBJLoader {
      */
     static bool loadModel(const std::string &path, std::vector<glm::vec3> &vertices, std::vector<glm::vec3> &normals,
                           std::vector<glm::vec2> &texCoords, std::vector<uint32_t> &indices);
+
+    static bool loadModel(const std::string &path, std::vector<Shape> &shape);
 };
 
 } // namespace ES::Plugin::Object::Resource

--- a/src/plugin/object/src/utils/Shape.hpp
+++ b/src/plugin/object/src/utils/Shape.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <vector>
+#include <glm/vec2.hpp>
+#include <glm/vec3.hpp>
+
+struct Shape
+{
+    std::vector<glm::vec3> vertices;
+    std::vector<glm::vec3> normals;
+    std::vector<glm::vec2> texCoords;
+    std::vector<uint32_t> indices;
+};

--- a/src/plugin/object/src/utils/Shape.hpp
+++ b/src/plugin/object/src/utils/Shape.hpp
@@ -1,11 +1,10 @@
 #pragma once
 
-#include <vector>
 #include <glm/vec2.hpp>
 #include <glm/vec3.hpp>
+#include <vector>
 
-struct Shape
-{
+struct Shape {
     std::vector<glm::vec3> vertices;
     std::vector<glm::vec3> normals;
     std::vector<glm::vec2> texCoords;


### PR DESCRIPTION
Related to no issues.

Introduces a new Shape struct to encapsulate mesh data and extends OBJLoader with a new loadModel overload that loads OBJ files into a vector of Shape objects. This enables more flexible handling of complex OBJ files with multiple shapes.