### PR TITLE
fix(Sound): pcm frame reset for non-looping sounds

### DIFF
--- a/src/plugin/sound/src/resource/SoundManager.hpp
+++ b/src/plugin/sound/src/resource/SoundManager.hpp
@@ -96,6 +96,7 @@ class SoundManager {
                     }
                     else
                     {
+                        ma_decoder_seek_to_pcm_frame(&sound.decoder, 0);
                         sound.isPlaying = false;
                         break;
                     }


### PR DESCRIPTION
Not related to any issue.

The SoundPlugin is able to play sounds without specifying any loop. The sound will play once but won't be able to play again unless stopped intentionally by the user. This PR provides a fix by setting back the PCM frame to the beginning after the sound has been played entirely.