### PR TITLE
feat(RenderingPipeline): define ctor for schedulers and plugins

### DIFF
--- a/src/plugin/rendering-pipeline/src/plugin/PluginRenderingPipeline.hpp
+++ b/src/plugin/rendering-pipeline/src/plugin/PluginRenderingPipeline.hpp
@@ -18,7 +18,9 @@ namespace ES::Plugin::RenderingPipeline {
  */
 class Plugin : public ES::Engine::APlugin {
   public:
-    using APlugin::APlugin;
+    explicit Plugin(ES::Engine::Core &core): ES::Engine::APlugin(core){
+        // empty
+    };
     virtual ~Plugin() = default;
 
     void Bind() final;

--- a/src/plugin/rendering-pipeline/src/scheduler/Init.hpp
+++ b/src/plugin/rendering-pipeline/src/scheduler/Init.hpp
@@ -8,7 +8,8 @@ namespace ES::Plugin::RenderingPipeline {
  */
 class Init : public ES::Engine::Scheduler::AScheduler {
   public:
-    using AScheduler::AScheduler;
+    Init(ES::Engine::Core &core) : AScheduler(core) {};
+
     void RunSystems() override;
 };
 } // namespace ES::Plugin::RenderingPipeline

--- a/src/plugin/rendering-pipeline/src/scheduler/Init.hpp
+++ b/src/plugin/rendering-pipeline/src/scheduler/Init.hpp
@@ -8,7 +8,7 @@ namespace ES::Plugin::RenderingPipeline {
  */
 class Init : public ES::Engine::Scheduler::AScheduler {
   public:
-    Init(ES::Engine::Core &core) : AScheduler(core) {};
+    Init(ES::Engine::Core &core) : AScheduler(core){};
 
     void RunSystems() override;
 };

--- a/src/plugin/rendering-pipeline/src/scheduler/Setup.hpp
+++ b/src/plugin/rendering-pipeline/src/scheduler/Setup.hpp
@@ -8,7 +8,7 @@ namespace ES::Plugin::RenderingPipeline {
  */
 class Setup : public ES::Engine::Scheduler::AScheduler {
   public:
-    Setup(ES::Engine::Core &core) : AScheduler(core) {};
+    Setup(ES::Engine::Core &core) : AScheduler(core){};
 
     void RunSystems() override;
 };

--- a/src/plugin/rendering-pipeline/src/scheduler/Setup.hpp
+++ b/src/plugin/rendering-pipeline/src/scheduler/Setup.hpp
@@ -8,7 +8,8 @@ namespace ES::Plugin::RenderingPipeline {
  */
 class Setup : public ES::Engine::Scheduler::AScheduler {
   public:
-    using AScheduler::AScheduler;
+    Setup(ES::Engine::Core &core) : AScheduler(core) {};
+
     void RunSystems() override;
 };
 } // namespace ES::Plugin::RenderingPipeline

--- a/src/plugin/window/src/plugin/PluginWindow.hpp
+++ b/src/plugin/window/src/plugin/PluginWindow.hpp
@@ -5,8 +5,9 @@
 namespace ES::Plugin::Window {
 class Plugin : public ES::Engine::APlugin {
   public:
-    using APlugin::APlugin;
-    ;
+    explicit Plugin(ES::Engine::Core &core): ES::Engine::APlugin(core){
+        // empty
+    };
     ~Plugin() = default;
 
     void Bind() final;


### PR DESCRIPTION
Related to no issues.

As @EngineSquared/coreteam can see in (private) Epitech repository, ES RS and Rolling ball projects doesn't compile because it doesnt find plugins, and schedulers setup, so this PR should define those missing ctors. 