### PR TITLE
ci: increase timeout for CI build and test steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
 
       - name: Build project
         run: xmake build -y
-        timeout-minutes: 8
+        timeout-minutes: 120
 
   check_examples:
     name: Build and test examples
@@ -226,20 +226,20 @@ jobs:
         if: contains(runner.os, 'linux')
         run: |
           xmake test -y -D
-        timeout-minutes: 8
+        timeout-minutes: 120
 
       - name: Run tests (Windows)
         if: contains(runner.os, 'windows')
         shell: pwsh
         run: |
           xmake test -y -D
-        timeout-minutes: 8
+        timeout-minutes: 120
 
       - name: Run tests (macOS)
         if: contains(runner.os, 'macos')
         run: |
           xmake test -y -D
-        timeout-minutes: 8
+        timeout-minutes: 120
 
       - name: Check test coverage (Linux)
         if: contains(runner.os, 'linux')


### PR DESCRIPTION
Not related to any issues

Increased timeout for build and test steps from 8 to 120 minutes to allow for longer execution times.