### PR TITLE
fix: set physics rigid bodies default layers properly

### DIFF
--- a/src/plugin/physics/src/component/RigidBody.hpp
+++ b/src/plugin/physics/src/component/RigidBody.hpp
@@ -23,10 +23,10 @@
 
 #pragma once
 
+#include "utils/Layers.hpp"
 #include <Jolt/Physics/Body/MotionType.h>
 #include <Jolt/Physics/EActivation.h>
 #include <cstdint>
-#include "utils/Layers.hpp"
 
 namespace Physics::Component {
 


### PR DESCRIPTION
Not related to any issues

The default layers for rigid bodies were not set, which required to set them manually after creating (tedious)
Now, we set default layers that are appropriate to each object type