### PR TITLE
feat(graphic): update header file inclusions for improved structure

### DIFF
--- a/src/plugin/graphic/xmake.lua
+++ b/src/plugin/graphic/xmake.lua
@@ -2,7 +2,6 @@ includes("../../engine/xmake.lua")
 includes("../../utils/log/xmake.lua")
 includes("../object/xmake.lua")
 includes("../rendering-pipeline/xmake.lua")
-includes("../object/xmake.lua")
 includes("../window/xmake.lua")
 
 local required_packages = {


### PR DESCRIPTION
 I tried using xrepo, but these headers are missing from the xmake.lua file in the graphic plugin.
 ```lua
add_headerfiles("src/(component/*.hpp)")
add_headerfiles("src/(system/GPUComponentManagement/*.hpp)")
add_headerfiles("src/(system/preparation/*.hpp)")
add_headerfiles("src/(system/presentation/*.hpp)")
add_headerfiles("src/(utils/shader/*.hpp)")
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reorganized header file inclusions and internal build configuration for the graphics plugin.
  * Added several header patterns to improve component and shader coverage while retaining existing headers.
  * No changes to runtime behavior, public APIs, or exported declarations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->