### PR TITLE
feat(core): return SystemIDs in plugin abstract RegisterSystems

### DIFF
--- a/src/engine/tests/engine/PluginTest.cpp
+++ b/src/engine/tests/engine/PluginTest.cpp
@@ -2,7 +2,6 @@
 
 #include "core/Core.hpp"
 #include "plugin/APlugin.hpp"
-#include "scheduler/Startup.hpp"
 
 struct ResourceTest {
     std::vector<std::string> data;


### PR DESCRIPTION
Not related to any issues.

Small ECS feature yet very useful: while trying to disable a system, I encountered an issue where it was impossible to get the SystemID from a system registered with Plugin::Bind, because APlugin::RegisterSystems returned void.

Usually plugins should stay untouched by end users, and enabling/disabling something should be done with a resource.
But if we want to provide them a way to disable a specific system, it would be the following:
- Store the specific FunctionID that got added when binding the plugin in the plugin struct itself
- User adds a system that gets the plugin to access the FunctionID
- User do what they want with the SystemID, including calling Scheduler::Disable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced error handling for missing plugins.

* **Refactor**
  * Updated plugin registration system API.

* **Tests**
  * Added plugin system tests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->