### PR TITLE
fix(ui): update render pass dependency to use DEFERRED_PASS

### DIFF
--- a/src/plugin/rmlui/src/system/CreateRmluiRenderPipeline.cpp
+++ b/src/plugin/rmlui/src/system/CreateRmluiRenderPipeline.cpp
@@ -44,8 +44,8 @@ void Rmlui::System::CreateRmluiRenderPipeline(Engine::Core &core)
     renderPass.AddOutput(0, std::move(colorOutput));
 
     renderGraph.Add(Utils::RMLUI_RENDER_PASS_NAME, std::move(renderPass));
-    if (renderGraph.Contains("DEFAULT_RENDER_PASS"))
+    if (renderGraph.Contains("DEFERRED_PASS"))
     {
-        renderGraph.SetDependency("DEFAULT_RENDER_PASS", Utils::RMLUI_RENDER_PASS_NAME);
+        renderGraph.SetDependency("DEFERRED_PASS", Utils::RMLUI_RENDER_PASS_NAME);
     }
 }


### PR DESCRIPTION
This pull request updates the dependency logic for the Rmlui render pipeline to ensure it integrates correctly with the deferred rendering pass. The main change is to check for and set dependencies against the `DEFERRED_PASS` instead of the previous `DEFAULT_RENDER_PASS`.

Render pipeline dependency update:

* In `CreateRmluiRenderPipeline.cpp`, the code now checks for the existence of `DEFERRED_PASS` in the render graph and sets the dependency accordingly, replacing the old check and dependency on `DEFAULT_RENDER_PASS`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted rendering pipeline dependency configuration to ensure correct visual layer composition during rendering.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->