### PR TITLE
fix: update framebuffer size callback to use window resource size

### DIFF
--- a/src/plugin/window/src/system/WindowSystem.cpp
+++ b/src/plugin/window/src/system/WindowSystem.cpp
@@ -59,8 +59,7 @@ void SetupWindowCallbacks(Engine::Core &core)
     glfwSetFramebufferSizeCallback(glfwWindow, [](GLFWwindow *window, int width, int height) {
         auto core = static_cast<Engine::Core *>(glfwGetWindowUserPointer(window));
         const auto &windowResource = core->GetResource<Resource::Window>();
-        const auto size = windowResource.GetSize();
-        const glm::ivec2 newSize{static_cast<int>(size.x), static_cast<int>(size.y)};
+        const auto newSize = windowResource.GetSize();
         auto &eventManager = core->GetResource<::Event::Resource::EventManager>();
         eventManager.PushEvent(Window::Event::OnResize{newSize});
     });


### PR DESCRIPTION
## Description
This pull request refines how window resize events are handled in the `WindowSystem.cpp` file. Instead of using the raw width and height values provided by the GLFW callback, the code now retrieves the window size from the `Window` resource, ensuring consistency across the application.

## Related Issues

None

## Type of Change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made
List the main changes in this PR:
- Used window size for OnResize Window event

## Testing
Describe the tests you ran to verify your changes:
- [x] Run on real application

### Test Environment
- OS: macOS 26.3.1
- Compiler: Apple clang 1700.6.4.2

## Screenshots/Videos (if applicable)
None

## Documentation
- [x] No documentation changes are required

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

## Breaking Changes
None

## Additional Notes
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed window resize event handling to use the actual window resource size from the core system, preventing size mismatches and ensuring components receive correct resize notifications.
  * Improves stability and consistency of rendering and layout after window resizes across the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->