### PR TITLE
fix: add pull_request branch ignore rules to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,8 @@ on:
       - 'ga-ignore-**'
       - 'gh-pages'
   pull_request:
-    branches-ignore:
-      - 'ga-ignore-**'
-      - 'gh-pages'
+    branches:
+      - '**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -19,6 +18,7 @@ env:
 
 jobs:
   check_repository_cleanliness:
+    if: ${{ github.event_name != 'pull_request' || (!startsWith(github.head_ref, 'ga-ignore-') && github.head_ref != 'gh-pages') }}
     name: Checks if the repository is clean and void of any unwanted files (temp files, binary files, etc.)
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
# Pull Request

## Description
I added ci run on pull request

## Related Issues

None

## Type of Change
Please delete options that are not relevant.

- [x] Build/CI configuration change

## Changes Made
List the main changes in this PR:
- Added pull_request event triggering with branch excludes

## Testing

None

### Test Environment
- OS: macOS
- Compiler: apple clang

## Documentation
- [ ] I have updated the relevant documentation
- [ ] I have added/updated comments in the code
- [x] No documentation changes are required

## Checklist
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Breaking Changes

None

## Additional Notes

None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow now also runs on pull request events, using the same branch filters as push triggers.
  * Simplified checkout steps by removing explicit reference parameters.
  * Removed an automatic "pull latest changes" step from the examples check job.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->