### PR TITLE
docs: add quality indicator badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 # Engine² (or Engine Squared)
 
+[![CI](https://github.com/EngineSquared/EngineSquared/actions/workflows/ci.yml/badge.svg)](https://github.com/EngineSquared/EngineSquared/actions/workflows/ci.yml)
+[![License](https://img.shields.io/github/license/EngineSquared/EngineSquared)](LICENSE)
+[![Release](https://img.shields.io/github/v/release/EngineSquared/EngineSquared)](https://github.com/EngineSquared/EngineSquared/releases)
+[![Issues](https://img.shields.io/github/issues/EngineSquared/EngineSquared)](https://github.com/EngineSquared/EngineSquared/issues)
+[![Stars](https://img.shields.io/github/stars/EngineSquared/EngineSquared)](https://github.com/EngineSquared/EngineSquared/stargazers)
+
 Open-source game engine written in C++.
 <br>
 


### PR DESCRIPTION
## Summary

This PR adds quality indicator badges to the README as requested in #535.

### Badges Added:
- **CI Status** - Shows the build status from GitHub Actions
- **License** - Displays the MIT license
- **Release** - Shows the latest release version
- **Issues** - Displays the number of open issues
- **Stars** - Shows the project star count

### Changes:
- Added a badge section below the project title in README.md
- All badges link to their respective pages (Actions, License, Releases, Issues, Stargazers)

### Testing:
- Verified badge URLs are correct and resolve properly
- Confirmed README renders correctly with new badges

Closes #535

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added status badges to the README displaying CI workflow status, license information, latest release version, open issues count, and GitHub stars.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->