### PR TITLE
refactor(core): rename RunCore to Run for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ int main() {
     auto entity = core.CreateEntity();
     entity.AddComponent<NameComponent>("Alice");
 
-    core.RunSystems(); // starts the game loop, RunSystems() run them only one time and Run() run all scheduler indefinitely until Stop() is called
+    core.RunSystems(); // Executes systems once; use Run() to run the scheduler repeatedly until Stop() is called.
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ int main() {
     auto entity = core.CreateEntity();
     entity.AddComponent<NameComponent>("Alice");
 
-    core.RunSystems(); // starts the game loop, RunSystems() run them only one time and RunCore() run all scheduler indefinitely until Stop() is called
+    core.RunSystems(); // starts the game loop, RunSystems() run them only one time and Run() run all scheduler indefinitely until Stop() is called
 }
 ```
 

--- a/examples/basic_core_usage/src/main.cpp
+++ b/examples/basic_core_usage/src/main.cpp
@@ -118,7 +118,7 @@ int main(void)
     pugo.AddComponent<NameComponent>("Pugo");
     pugo.AddComponent<WorkTimeComponent>({.maxHours = 6});
 
-    core.RunCore();
+    core.Run();
 
     return 0;
 }

--- a/examples/character_controller_usage/src/main.cpp
+++ b/examples/character_controller_usage/src/main.cpp
@@ -310,7 +310,7 @@ int main(void)
     core.RegisterSystem<Engine::Scheduler::Startup>(SetupCharacterControllerScene);
     core.RegisterSystem<Engine::Scheduler::Update>(CharacterControllerInputSystem);
 
-    core.RunCore();
+    core.Run();
 
     return 0;
 }

--- a/examples/graphic_light_usage/src/main.cpp
+++ b/examples/graphic_light_usage/src/main.cpp
@@ -161,7 +161,7 @@ int main(void)
 
     try
     {
-        core.RunCore();
+        core.Run();
     }
     catch (const GraphicExampleError &e)
     {

--- a/examples/graphic_material_usage/src/main.cpp
+++ b/examples/graphic_material_usage/src/main.cpp
@@ -101,7 +101,7 @@ int main(void)
 
     try
     {
-        core.RunCore();
+        core.Run();
     }
     catch (const GraphicExampleError &e)
     {

--- a/examples/graphic_usage/src/main.cpp
+++ b/examples/graphic_usage/src/main.cpp
@@ -101,7 +101,7 @@ int main(void)
 
     core.RegisterSystem<Engine::Scheduler::Startup>(Setup);
 
-    core.RunCore();
+    core.Run();
 
     return 0;
 }

--- a/examples/graphic_usage_with_physics/src/main.cpp
+++ b/examples/graphic_usage_with_physics/src/main.cpp
@@ -135,7 +135,7 @@ int main(void)
 
     core.RegisterSystem<Engine::Scheduler::Startup>(Setup);
 
-    core.RunCore();
+    core.Run();
 
     return 0;
 }

--- a/examples/input_usage/src/main.cpp
+++ b/examples/input_usage/src/main.cpp
@@ -73,7 +73,7 @@ int main(void)
         }
     });
 
-    core.RunCore();
+    core.Run();
 
     return 0;
 }

--- a/examples/physics_usage/src/main.cpp
+++ b/examples/physics_usage/src/main.cpp
@@ -238,7 +238,7 @@ int main(void)
     std::cout << "  Running Physics Simulation" << std::endl;
     std::cout << "========================================" << std::endl;
 
-    core.RunCore();
+    core.Run();
 
     std::cout << "\n========================================" << std::endl;
     std::cout << "  Simulation Complete!" << std::endl;

--- a/examples/rmlui_usage/src/Animation.cpp
+++ b/examples/rmlui_usage/src/Animation.cpp
@@ -57,7 +57,7 @@ int main(void)
 
     core.RegisterSystem<Engine::Scheduler::Startup>(demo_setup::Setup);
 
-    core.RunCore();
+    core.Run();
 
     return 0;
 }

--- a/examples/rmlui_usage/src/Demo.cpp
+++ b/examples/rmlui_usage/src/Demo.cpp
@@ -622,7 +622,7 @@ int main(void)
 
     core.RegisterSystem<Engine::Scheduler::Startup>(demo_setup::Setup);
 
-    core.RunCore();
+    core.Run();
 
     return 0;
 }

--- a/examples/rmlui_usage/src/Transform.cpp
+++ b/examples/rmlui_usage/src/Transform.cpp
@@ -57,7 +57,7 @@ int main(void)
 
     core.RegisterSystem<Engine::Scheduler::Startup>(Setup);
 
-    core.RunCore();
+    core.Run();
 
     return 0;
 }

--- a/examples/rmlui_usage/src/main.cpp
+++ b/examples/rmlui_usage/src/main.cpp
@@ -312,7 +312,7 @@ int main(void)
 
     core.RegisterSystem<Engine::Scheduler::Startup>(Setup);
 
-    core.RunCore();
+    core.Run();
 
     return 0;
 }

--- a/examples/softbody_usage/src/main.cpp
+++ b/examples/softbody_usage/src/main.cpp
@@ -199,7 +199,7 @@ int main(void)
 
     try
     {
-        core.RunCore();
+        core.Run();
     }
     catch (const GraphicExampleError &e)
     {

--- a/examples/sound_usage/src/main.cpp
+++ b/examples/sound_usage/src/main.cpp
@@ -31,7 +31,7 @@ int main(void)
 
     core.RegisterSystem<Engine::Scheduler::Startup>(SetupSound);
 
-    core.RunCore();
+    core.Run();
 
     return 0;
 }

--- a/examples/vehicle_usage/src/main.cpp
+++ b/examples/vehicle_usage/src/main.cpp
@@ -73,7 +73,7 @@ int main(void)
 
     core.RegisterSystem<Engine::Scheduler::Startup>(Setup);
 
-    core.RunCore();
+    core.Run();
 
     return 0;
 }

--- a/src/engine/src/core/Core.cpp
+++ b/src/engine/src/core/Core.cpp
@@ -75,7 +75,7 @@ void Engine::Core::Stop()
     _running = false;
 }
 
-void Engine::Core::RunCore()
+void Engine::Core::Run(void)
 {
     _running = true;
     while (_running)

--- a/src/engine/src/core/Core.hpp
+++ b/src/engine/src/core/Core.hpp
@@ -130,8 +130,8 @@ class Core {
     /// @brief Stop the core execution. It will finish the current loop, call shutdown systems if any and stop.
     void Stop();
 
-    /// @brief Execute the core loop, which will run all the schedulers.
-    void RunCore();
+    /// @brief Run a loop of schedulers until _running is false.
+    void Run(void);
 
     /// @brief Add one or multiple systems associated with a specific scheduler.
     /// @tparam TScheduler The type of the scheduler to use. It must be derived from AScheduler. You can look at

--- a/src/plugin/graphic/README.md
+++ b/src/plugin/graphic/README.md
@@ -151,7 +151,7 @@ int main() {
 
     core.AddPlugins<Window::Plugin, DefaultPipeline::Plugin, Graphic::Plugin>();
     // Configure GraphicSettings in Init if needed (see Configuration)
-    core.RunCore();
+    core.Run();
     return 0;
 }
 ```

--- a/src/plugin/physics/tests/VehicleForwardMovementTest.cpp
+++ b/src/plugin/physics/tests/VehicleForwardMovementTest.cpp
@@ -112,5 +112,5 @@ TEST(VehiclePlugin, VehicleForwardMovement)
         }
     });
 
-    c.RunCore();
+    c.Run();
 }


### PR DESCRIPTION
# Pull Request

## Description

Renamed "RunCore" method to "Run".

## Related Issues (Put "None" if there are no related issues)

close #489 

## Type of Change
Please delete options that are not relevant.

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Changes Made
List the main changes in this PR:
- Renamed "RunCore" method to "Run"

## Testing
Describe the tests you ran to verify your changes. Please delete options that are not relevant.
- Unit tests pass (`xmake test`)

### Test Environment
- OS: macOS
- Compiler: Clang

## Screenshots/Videos (Put "None" if there are no related issues)

None

## Documentation
Please delete options that are not relevant.

- No documentation changes are required

## Checklist (Don't delete any options)
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Breaking Changes (Put "None" if there are no related issues)

None

## Additional Notes (Put "None" if there are no related issues)

None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * The engine startup API was renamed; update application initialization to use the new startup call.

* **Documentation**
  * Examples and docs updated to show the new startup approach.

* **Tests**
  * Test harnesses updated to invoke the new startup entrypoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->