### PR TITLE
docs(adr): specify how to write an Architecture Decision Record (ADR)

### DIFF
--- a/docs/decisions/00-adr-template.md
+++ b/docs/decisions/00-adr-template.md
@@ -1,5 +1,17 @@
-<!-- This template comes from MADR (https://adr.github.io/madr/) -->
+---
+# This template comes from MADR (https://adr.github.io/madr/)
 
+issue: ADR-000          # ADR identifier
+title: …
+branch: …               # feature branch name
+status: todo            # see lifecycle below
+pr: ~                   # GitHub PR number, or ~ if not yet opened
+pr_url: ~               # full URL to the PR, or ~
+github_issue: ~         # GitHub Issue number, or ~
+github_issue_url: ~     # full URL to the issue, or ~
+depends_on: []          # ADRs that must be completed before this one starts
+required_by: []         # ADRs that cannot start until this one is completed
+---
 # {short title, representative of solved problem and found solution}
 
 ## Status
@@ -72,3 +84,7 @@ Chosen option: "{title of option 1}", because {justification. e.g., only option,
 
 {You might want to provide additional evidence/confidence for the decision outcome here and/or document the team agreement on the decision and/or define when/how this decision should be realized and if/when it should be re-visited. Links to other decisions and resources might appear here as well.}
 
+<!-- This is an optional element. Feel free to remove. -->
+## Abandonment
+
+{Why was this ADR dropped and what replaces it, if anything?}

--- a/docs/decisions/00-adr-template.md
+++ b/docs/decisions/00-adr-template.md
@@ -1,0 +1,68 @@
+<!-- This template come from MADR (https://adr.github.io/madr/) -->
+
+# {short title, representative of solved problem and found solution}
+
+## Context and Problem Statement
+
+{Describe the context and problem statement, e.g., in free form using two to three sentences or in the form of an illustrative story. You may want to articulate the problem in form of a question and add links to collaboration boards or issue management systems.}
+
+<!-- This is an optional element. Feel free to remove. -->
+## Decision Drivers
+
+* {decision driver 1, e.g., a force, facing concern, …}
+* {decision driver 2, e.g., a force, facing concern, …}
+* … <!-- numbers of drivers can vary -->
+
+## Considered Options
+
+* {title of option 1}
+* {title of option 2}
+* {title of option 3}
+* … <!-- numbers of options can vary -->
+
+## Decision Outcome
+
+Chosen option: "{title of option 1}", because {justification. e.g., only option, which meets k.o. criterion decision driver | which resolves force {force} | … | comes out best (see below)}.
+
+<!-- This is an optional element. Feel free to remove. -->
+### Consequences
+
+* Good, because {positive consequence, e.g., improvement of one or more desired qualities, …}
+* Bad, because {negative consequence, e.g., compromising one or more desired qualities, …}
+* … <!-- numbers of consequences can vary -->
+
+<!-- This is an optional element. Feel free to remove. -->
+### Confirmation
+
+{Describe how the implementation of/compliance with the ADR can/will be confirmed. Is the chosen design and its implementation in line with the decision? E.g., a design/code review or a test with a library such as ArchUnit can help validate this. Note that although we classify this element as optional, it is included in many ADRs.}
+
+<!-- This is an optional element. Feel free to remove. -->
+## Pros and Cons of the Options
+
+### {title of option 1}
+
+<!-- This is an optional element. Feel free to remove. -->
+{example | description | pointer to more information | …}
+
+* Good, because {argument a}
+* Good, because {argument b}
+<!-- use "neutral" if the given argument weights neither for good nor bad -->
+* Neutral, because {argument c}
+* Bad, because {argument d}
+* … <!-- numbers of pros and cons can vary -->
+
+### {title of other option}
+
+{example | description | pointer to more information | …}
+
+* Good, because {argument a}
+* Good, because {argument b}
+* Neutral, because {argument c}
+* Bad, because {argument d}
+* …
+
+<!-- This is an optional element. Feel free to remove. -->
+## More Information
+
+{You might want to provide additional evidence/confidence for the decision outcome here and/or document the team agreement on the decision and/or define when/how this decision the decision should be realized and if/when it should be re-visited. Links to other decisions and resources might appear here as well.}
+

--- a/docs/decisions/00-adr-template.md
+++ b/docs/decisions/00-adr-template.md
@@ -70,5 +70,5 @@ Chosen option: "{title of option 1}", because {justification. e.g., only option,
 <!-- This is an optional element. Feel free to remove. -->
 ## More Information
 
-{You might want to provide additional evidence/confidence for the decision outcome here and/or document the team agreement on the decision and/or define when/how this decision the decision should be realized and if/when it should be re-visited. Links to other decisions and resources might appear here as well.}
+{You might want to provide additional evidence/confidence for the decision outcome here and/or document the team agreement on the decision and/or define when/how this decision should be realized and if/when it should be re-visited. Links to other decisions and resources might appear here as well.}
 

--- a/docs/decisions/00-adr-template.md
+++ b/docs/decisions/00-adr-template.md
@@ -2,6 +2,12 @@
 
 # {short title, representative of solved problem and found solution}
 
+## Status
+{proposed | accepted | deprecated | superseded by ADR-XXXX}
+
+## Date
+{YYYY-MM-DD}
+
 ## Context and Problem Statement
 
 {Describe the context and problem statement, e.g., in free form using two to three sentences or in the form of an illustrative story. You may want to articulate the problem in form of a question and add links to collaboration boards or issue management systems.}

--- a/docs/decisions/00-adr-template.md
+++ b/docs/decisions/00-adr-template.md
@@ -1,4 +1,4 @@
-<!-- This template come from MADR (https://adr.github.io/madr/) -->
+<!-- This template comes from MADR (https://adr.github.io/madr/) -->
 
 # {short title, representative of solved problem and found solution}
 


### PR DESCRIPTION
# Pull Request

## Description
I specified how to write an Architecture Decision Record (ADR) to mark any big architectural change in the project.

## Related Issues (Put "None" if there are no related issues)

close #532 

## Type of Change
Please delete options that are not relevant.

- Documentation update

## Changes Made
List the main changes in this PR:
- Added ADR template inside `docs/decisions`

## Testing
Describe the tests you ran to verify your changes. Please delete options that are not relevant.

None

### Test Environment
- OS: macOS
- Compiler: Clang

## Screenshots/Videos (Put "None" if there are no related issues)

None

## Documentation
Please delete options that are not relevant.

- I have updated the relevant documentation

## Checklist (Don't delete any options)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Breaking Changes (Put "None" if there are no related issues)

None

## Additional Notes (Put "None" if there are no related issues)

None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new Architecture Decision Record (ADR) template to standardize ADR entries. Includes front-matter fields for metadata (identifier, title, status, references, dependencies) and a structured body with sections for status, date, context/problem, decision drivers, considered options, chosen outcome and justification, optional consequences, confirmation steps, pros/cons per option, further info, and abandonment notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->